### PR TITLE
Publish to public Patina NuGet feed

### DIFF
--- a/.nuget/dxe_core_config.yaml
+++ b/.nuget/dxe_core_config.yaml
@@ -4,5 +4,5 @@ description_string: QEMU DXE Core
 license_url: http://www.microsoft.com/
 name: DXECORE.QEMU
 project_url: https://microsoft.github.com/mu
-server_url: https://pkgs.dev.azure.com/microsoft/MsUEFI/_packaging/DxeRust/nuget/v3/index.json
+server_url: https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/qemu-dxe-core/nuget/v3/index.json
 tags_string: ''

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ dxe_core = { path = "../uefi-dxe-core/dxe_core" }
 
 ## NuGet Publishing Instructions
 
-The NuGet package is currently published to [DxeRust](https://dev.azure.com/microsoft/MsUEFI/_artifacts/feed/DxeRust)
-feed where it is consumed in the [UefiRust](https://dev.azure.com/microsoft/MsUEFI/_git/UefiRust) repository.
+The NuGet package is currently published to the public [Patina QEMU DXE Core](https://dev.azure.com/patina-fw/artifacts/_artifacts/feed/qemu-dxe-core)
+feed where it is consumed in the [Patina QEMU](https://github.com/OpenDevicePartnership/patina-qemu) repository.
 
-The NuGet is built and published using the [Publish Rust DXE Core pipeline](https://dev.azure.com/microsoft/MsUEFI/_build?definitionId=131978&_a=summary).
+The NuGet is built and published using a GitHub workflow in [Patina QEMU DXE Core Actions](https://github.com/OpenDevicePartnership/patina-dxe-core-qemu/actions).


### PR DESCRIPTION
## Description

Publishes the binary to a feed that is publicly accessible:

https://dev.azure.com/patina-fw/artifacts/_artifacts/feed/qemu-dxe-core

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Will be tested after repo CI is completed.

## Integration Instructions

- Pull from the binaries from the NuGet feed in the PR description.
- `NUGET_KEY` will need to be updated for this ADO organization.