### PR TITLE
Update the version to 0.3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qemu_dxe_core"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "BSD-2-Clause-Patent"
 


### PR DESCRIPTION
Update the version to `0.3.2`. This is primarily to avoid caching issues with the previous feed version of `0.3.1`.