### PR TITLE
Move Default Log Level to Info

### DIFF
--- a/bin/q35_dxe_core.rs
+++ b/bin/q35_dxe_core.rs
@@ -41,12 +41,11 @@ static LOGGER: AdvancedLogger<Uart16550> = AdvancedLogger::new(
     Format::Standard,
     &[
         ("goblin", log::LevelFilter::Off),
-        ("uefi_depex", log::LevelFilter::Off),
         ("gcd_measure", log::LevelFilter::Off),
         ("allocations", log::LevelFilter::Off),
         ("efi_memory_map", log::LevelFilter::Off),
     ],
-    log::LevelFilter::Trace,
+    log::LevelFilter::Info,
     Uart16550::Io { base: 0x402 },
 );
 

--- a/bin/sbsa_dxe_core.rs
+++ b/bin/sbsa_dxe_core.rs
@@ -36,12 +36,11 @@ static LOGGER: AdvancedLogger<UartPl011> = AdvancedLogger::new(
     Format::Standard,
     &[
         ("goblin", log::LevelFilter::Off),
-        ("uefi_depex", log::LevelFilter::Off),
         ("gcd_measure", log::LevelFilter::Off),
         ("allocations", log::LevelFilter::Off),
         ("efi_memory_map", log::LevelFilter::Off),
     ],
-    log::LevelFilter::Trace,
+    log::LevelFilter::Info,
     UartPl011::new(0x6000_0000),
 );
 


### PR DESCRIPTION
## Description

Most casual consumers of patina-dxe-core-qemu don't want trace level logs. Make this more useful by making it info by default. This also removes an old name of a target that is no longer needed because all logs there have been moved to trace.

Note that the PR moving depex logs to trace is currently open in patina.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on patina-qemu.

## Integration Instructions

N/A.
