### PR TITLE
fix: wrap unsafe attribute as required by Rust 2024 edition

### DIFF
--- a/bin/q35_dxe_core.rs
+++ b/bin/q35_dxe_core.rs
@@ -54,7 +54,7 @@ static DEBUGGER: patina_debugger::UefiDebugger<Uart16550> =
         .with_default_config(false, true, 0)
         .with_debugger_logging();
 
-#[cfg_attr(target_os = "uefi", export_name = "efi_main")]
+#[cfg_attr(target_os = "uefi", unsafe(export_name = "efi_main"))]
 pub extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
     log::set_logger(&LOGGER).map(|()| log::set_max_level(log::LevelFilter::Trace)).unwrap();
     let adv_logger_component = AdvancedLoggerComponent::<Uart16550>::new(&LOGGER);

--- a/bin/sbsa_dxe_core.rs
+++ b/bin/sbsa_dxe_core.rs
@@ -47,7 +47,7 @@ static LOGGER: AdvancedLogger<UartPl011> = AdvancedLogger::new(
 static DEBUGGER: patina_debugger::UefiDebugger<UartPl011> =
     patina_debugger::UefiDebugger::new(UartPl011::new(0x6000_0000)).with_default_config(false, true, 0);
 
-#[cfg_attr(target_os = "uefi", export_name = "efi_main")]
+#[cfg_attr(target_os = "uefi", unsafe(export_name = "efi_main"))]
 pub extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
     log::set_logger(&LOGGER).map(|()| log::set_max_level(log::LevelFilter::Trace)).unwrap();
     let adv_logger_component = AdvancedLoggerComponent::<UartPl011>::new(&LOGGER);


### PR DESCRIPTION
## Description

Address Rust 2024 lint [unsafe-attr-outside-unsafe](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unsafe-attr-outside-unsafe)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

NA

## Integration Instructions

NA
