### PR TITLE
Makefile.toml: Fix patch task exit code

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -207,7 +207,7 @@ if ${needs_patch}
     mv Cargo.toml.bak Cargo.toml
 end
 
-exit #{exit_code}
+exit ${exit_code}
 '''
 
 [tasks.build-efi]


### PR DESCRIPTION
## Description

Currently, the code returned is always '0' regardless of what is returned from `exec --get-exit-code cargo make build-efi`. This updates the syntax to return the actual code.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Dump `cargo make build` exit code
- Check return code in debugger

## Integration Instructions

N/A