### PR TITLE
Integrate MM refactor (Patina v2.0.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,9 +44,9 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2be5a46ba01b60005ae2c51a36a29cfe134bcacae2dd5cedcd4615fbaad1494b"
 dependencies = [
- "proc-macro2 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 2.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -95,8 +95,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e55ede5279d4d7c528906853743abeb26353ae1e6c440fcd6d18316c2c2dd903"
 dependencies = [
  "once_cell",
- "proc-macro2 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
  "rustc_version",
  "semver",
  "time",
@@ -146,7 +146,7 @@ checksum = "8062b93565ea9fe2e60a0dd3c252f0d48c27cf223dad7ead028e361181a2c1a5"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
- "log 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
  "managed",
  "num-traits",
  "paste",
@@ -154,13 +154,13 @@ dependencies = [
 
 [[package]]
 name = "goblin"
-version = "0.9.3"
-source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "daa0a64d21a7eb230583b4c5f4e23b7e4e57974f96620f42a7e75e08ae66d745"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e961b33649994dcf69303af6b3a332c1228549e604d455d61ec5d2ab5e68d3a"
 dependencies = [
- "log 0.4.27 (sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/)",
+ "log",
  "plain",
- "scroll 0.12.0 (sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/)",
+ "scroll 0.13.0",
 ]
 
 [[package]]
@@ -208,16 +208,16 @@ version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04d55ca5d5a14363da83bf3c33874b8feaa34653e760d5216d7ef9829c88001a"
 dependencies = [
- "proc-macro2 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 2.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -227,12 +227,6 @@ dependencies = [
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-
-[[package]]
-name = "log"
-version = "0.4.27"
-source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
@@ -271,7 +265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec6cd0d1d100d366e10f054039fdcf81002142d0561ed4eff7ed59bea370649c"
 dependencies = [
  "bitvec",
- "log 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
 ]
 
 [[package]]
@@ -291,7 +285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6011d836af33966e1ed8fc93e892dc722a733fa8537525cdee73a56ded76f0fa"
 dependencies = [
  "aarch64-cpu",
- "log 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
 ]
 
 [[package]]
@@ -323,11 +317,11 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "patina_adv_logger"
-version = "1.0.0"
+version = "2.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "616b9e92809a0bca23cc8eb80f682d2cae234dc860f1d4dea00b552d9e773c83"
+checksum = "374b262389ce020c940bc4f61fe8808ec150524a4b1cdbdb0a938771f055966e"
 dependencies = [
- "log 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
  "mu_pi",
  "mu_rust_helpers",
  "patina_sdk",
@@ -337,14 +331,14 @@ dependencies = [
 
 [[package]]
 name = "patina_debugger"
-version = "1.0.0"
+version = "2.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "4b04325afa54e737fb77f84d8db3158cd0997af7efcbf5f387dd272dbe392b68"
+checksum = "9f7909d311bbda79e528719cab3d7fb80404495c402abb460edfb339a2b1f952"
 dependencies = [
  "bitfield-struct",
  "cfg-if",
  "gdbstub",
- "log 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
  "patina_internal_cpu",
  "patina_paging",
  "patina_sdk",
@@ -353,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "patina_dxe_core"
-version = "1.0.0"
+version = "2.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "9801b12425d91989e66f0077d04906baee9b1d10d5f6379a5088d2cc4e32e6c7"
+checksum = "0ba5215ea0500fd3813c49361ece2a73ec1d79aab9c919b54b0151929680fb7a"
 dependencies = [
  "arm-gic",
  "compile-time",
@@ -363,7 +357,7 @@ dependencies = [
  "goblin",
  "lazy_static",
  "linked_list_allocator",
- "log 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
  "mu_pi",
  "mu_rust_helpers",
  "patina_debugger",
@@ -375,7 +369,7 @@ dependencies = [
  "patina_performance",
  "patina_sdk",
  "r-efi",
- "scroll 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scroll 0.12.0",
  "spin",
  "uefi_corosensei",
  "uuid",
@@ -383,23 +377,23 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_collections"
-version = "1.0.0"
+version = "2.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "c3007bad0e3bea04139b36462215d9d25850a9a811bbc9b2dbd8201afe11cc4e"
+checksum = "c99f5339ce55b953f7220680280ce03b7c3f84697c27cea6b9d755a804febc2b"
 dependencies = [
- "log 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
 ]
 
 [[package]]
 name = "patina_internal_cpu"
-version = "1.0.0"
+version = "2.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "2feb2d64318820a603de30fd8e756b5141832943d03bdd629f03b84c78053126"
+checksum = "0d037e3b38f39f946522d9e6fcdb36bb6a964f709bad949946545d5b114ceccb"
 dependencies = [
  "arm-gic",
  "cfg-if",
  "lazy_static",
- "log 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
  "mu_pi",
  "patina_mtrr",
  "patina_paging",
@@ -412,22 +406,35 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_depex"
-version = "1.0.0"
+version = "2.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "958cd4f2e66ed0c7162b3dc7b9ff06e25501131c523e0223013909eb61c964db"
+checksum = "65c3f4ae752797d58fd006a0f17129e967eb28ca323907adb6e1a48fbee17d54"
 dependencies = [
- "log 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
  "r-efi",
  "uuid",
 ]
 
 [[package]]
 name = "patina_internal_device_path"
-version = "1.0.0"
+version = "2.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "3393d2de06e44806d7884488ed5239169c4bbff2a5869fc40e266885a4cc5a7e"
+checksum = "503f583fb116bb4d2f90d6fd861024d7dfb8989f859f0c36575348da96ea0565"
 dependencies = [
  "r-efi",
+]
+
+[[package]]
+name = "patina_mm"
+version = "2.0.0"
+source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
+checksum = "422ba0beb464e6db8bf26445d552eecc4c7a437eee095e195f3d10afd9274cac"
+dependencies = [
+ "cfg-if",
+ "log",
+ "patina_sdk",
+ "r-efi",
+ "x86_64",
 ]
 
 [[package]]
@@ -442,53 +449,53 @@ dependencies = [
 
 [[package]]
 name = "patina_paging"
-version = "6.0.0"
+version = "7.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "0e1b6dbafed360dfc648f613b7aa69807c54f049d672f8b57d873e1bb2e0788d"
+checksum = "5c23f2f44841dfe194dd4e3dc0abd86c08ba1a76bfa429d1ce633a2707e36977"
 dependencies = [
  "bitfield-struct",
  "bitflags 2.9.1",
  "cfg-if",
- "log 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
 ]
 
 [[package]]
 name = "patina_performance"
-version = "1.0.0"
+version = "2.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "a0b8ee219b834d415f339f2cb7293c4852d45dd6a01b3d8dfd506b6eaa48bf0e"
+checksum = "d4f5be65bd92bb1a0cbc279ababfbc421208fa1da809905fc0b6c18170d3a287"
 dependencies = [
- "log 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
  "mu_pi",
  "mu_rust_helpers",
  "patina_internal_device_path",
  "patina_sdk",
  "r-efi",
- "scroll 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scroll 0.12.0",
  "uuid",
 ]
 
 [[package]]
 name = "patina_samples"
-version = "1.0.0"
+version = "2.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "78b307a20b5402f60fc1bd36ccc543f799ca2bf566a76e92e7d7bf63050b1b33"
+checksum = "a26ec80be250d7098ef77efe3cd3319522e5092e47ca1c5a5d6b85932a38abef"
 dependencies = [
- "log 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
  "patina_sdk",
 ]
 
 [[package]]
 name = "patina_sdk"
-version = "1.0.0"
+version = "2.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "05e162a302863c379e214742699baaa95bf82dd2e9152c37be1253723d1d7b65"
+checksum = "39692883e48e144585557dae8305fbb7884ecedacf19711a9897d48f875eadc6"
 dependencies = [
  "cfg-if",
  "fallible-streaming-iterator",
  "fixedbitset",
  "linkme",
- "log 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
  "mu_pi",
  "patina_sdk_macro",
  "r-efi",
@@ -498,26 +505,26 @@ dependencies = [
 
 [[package]]
 name = "patina_sdk_macro"
-version = "1.0.0"
+version = "2.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "06bad8059090143fc73b17917f1e2a4b581c344c478c8a0fee8060dc9961ce5d"
+checksum = "17ec5e96e745119e199dd3c097b123e570063ae9bc8f805a438a1536fe9af9a6"
 dependencies = [
- "proc-macro2 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 2.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "syn",
  "uuid",
 ]
 
 [[package]]
 name = "patina_section_extractor"
-version = "1.0.0"
+version = "2.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "43afab0f509c7091af76073c4887443c19f8e50e2008cb8d229ef4e393d4101a"
+checksum = "0e7e067f443fa11b7448084109e5f89e04e4c7d07a2771bbea46987be463f49c"
 dependencies = [
  "alloc-no-stdlib",
  "brotli-decompressor",
  "crc32fast",
- "log 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
  "mu_pi",
  "mu_rust_helpers",
  "patina_sdk",
@@ -526,18 +533,18 @@ dependencies = [
 
 [[package]]
 name = "patina_stacktrace"
-version = "1.0.0"
+version = "2.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "a1c1c0cd45c3f4d9bf6c92adde57627036eceae0f6ff55d791c0a422d3fa1290"
+checksum = "ed1b3c91c3f70a07d3fc289c15fb7a32aafff22ea62d08f99bd2b186d471f6a0"
 dependencies = [
  "cfg-if",
- "log 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
 ]
 
 [[package]]
 name = "plain"
 version = "0.2.3"
-source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
@@ -552,26 +559,18 @@ version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
- "unicode-ident 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.95"
-source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
-dependencies = [
- "unicode-ident 1.0.18 (sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/)",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "qemu_dxe_core"
 version = "0.3.2"
 dependencies = [
- "log 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log",
  "patina_adv_logger",
  "patina_debugger",
  "patina_dxe_core",
+ "patina_mm",
  "patina_samples",
  "patina_sdk",
  "patina_section_extractor",
@@ -586,16 +585,7 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
- "proc-macro2 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.40"
-source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
-dependencies = [
- "proc-macro2 1.0.95 (sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/)",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -630,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "scopeguard"
@@ -646,16 +636,16 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
 dependencies = [
- "scroll_derive 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scroll_derive 0.12.1",
 ]
 
 [[package]]
 name = "scroll"
-version = "0.12.0"
-source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1257cd4248b4132760d6524d6dda4e053bc648c9070b960929bf50cfb1e7add"
 dependencies = [
- "scroll_derive 0.12.1 (sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/)",
+ "scroll_derive 0.13.0",
 ]
 
 [[package]]
@@ -664,20 +654,20 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
- "proc-macro2 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 2.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "scroll_derive"
-version = "0.12.1"
-source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fc4f90c27b57691bbaf11d8ecc7cfbfe98a4da6dbe60226115d322aa80c06e"
 dependencies = [
- "proc-macro2 1.0.95 (sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/)",
- "quote 1.0.40 (sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/)",
- "syn 2.0.101 (sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/)",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -701,9 +691,9 @@ version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
- "proc-macro2 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 2.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -730,20 +720,9 @@ version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
- "proc-macro2 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-ident 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.101"
-source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
-dependencies = [
- "proc-macro2 1.0.95 (sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/)",
- "quote 1.0.40 (sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/)",
- "unicode-ident 1.0.18 (sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/)",
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -818,16 +797,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.18"
-source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 
 [[package]]
 name = "volatile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,14 @@ path = "src/lib.rs"
 log = { version = "^0.4", default-features = false, features = [
     "release_max_level_warn",
 ] }
-patina_adv_logger = { version = "1", registry = "patina-fw" }
-patina_debugger = { version = "1", registry = "patina-fw" }
-patina_dxe_core = { version = "1", registry = "patina-fw" }
-patina_samples = { version = "1", registry = "patina-fw" }
-patina_sdk = { version = "1", registry = "patina-fw" }
-patina_section_extractor = { version = "1", registry = "patina-fw" }
-patina_stacktrace = { version = "1", registry = "patina-fw" }
+patina_adv_logger = { version = "2", registry = "patina-fw" }
+patina_debugger = { version = "2", registry = "patina-fw" }
+patina_dxe_core = { version = "2", registry = "patina-fw" }
+patina_mm = { version = "2", registry = "patina-fw" }
+patina_samples = { version = "2", registry = "patina-fw" }
+patina_sdk = { version = "2", registry = "patina-fw" }
+patina_section_extractor = { version = "2", registry = "patina-fw" }
+patina_stacktrace = { version = "2", registry = "patina-fw" }
 r-efi = { version = "^5", default-features = false }
 x86_64 = { version = "=0.15.2", default-features = false, features = [
   "instructions"

--- a/bin/q35_dxe_core.rs
+++ b/bin/q35_dxe_core.rs
@@ -14,8 +14,6 @@ use core::{ffi::c_void, panic::PanicInfo};
 use patina_adv_logger::{component::AdvancedLoggerComponent, logger::AdvancedLogger};
 use patina_dxe_core::Core;
 use patina_samples as sc;
-use patina_sdk::component::config as uefi_sdk_configs;
-use patina_sdk::component::service as uefi_sdk_services;
 use patina_sdk::{log::Format, serial::uart::Uart16550};
 use patina_stacktrace::StackTrace;
 use qemu_resources::q35::component::service as q35_services;
@@ -73,16 +71,16 @@ pub extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
         .with_component(sc::HelloStruct("World")) // Example of a struct component
         .with_component(sc::GreetingsEnum::Hello("World")) // Example of a struct component (enum)
         .with_component(sc::GreetingsEnum::Goodbye("World")) // Example of a struct component (enum)
-        .with_config(uefi_sdk_configs::mm::MmCommunicationConfiguration {
-            acpi_base: uefi_sdk_configs::mm::AcpiBase::Mmio(0x0), // Actual ACPI base address will be set during boot
-            cmd_port: uefi_sdk_configs::mm::MmiPort::Smi(0xB2),
-            data_port: uefi_sdk_configs::mm::MmiPort::Smi(0xB3),
+        .with_config(patina_mm::config::MmCommunicationConfiguration {
+            acpi_base: patina_mm::config::AcpiBase::Mmio(0x0), // Actual ACPI base address will be set during boot
+            cmd_port: patina_mm::config::MmiPort::Smi(0xB2),
+            data_port: patina_mm::config::MmiPort::Smi(0xB3),
             comm_buffers: vec![],
         })
         .with_component(q35_services::mm_config_provider::MmConfigurationProvider)
         .with_component(q35_services::mm_control::QemuQ35PlatformMmControl::new())
-        .with_component(uefi_sdk_services::sw_mmi_manager::SwMmiManager::new())
-        .with_component(uefi_sdk_services::mm_communicator::MmCommunicator::new())
+        .with_component(patina_mm::component::sw_mmi_manager::SwMmiManager::new())
+        .with_component(patina_mm::component::communicator::MmCommunicator::new())
         .with_component(q35_services::mm_test::QemuQ35MmTest::new())
         .start()
         .unwrap();

--- a/src/q35/component/service/mm_config_provider.rs
+++ b/src/q35/component/service/mm_config_provider.rs
@@ -9,9 +9,9 @@
 //! SPDX-License-Identifier: BSD-2-Clause-Patent
 //!
 
+use patina_mm::config::{CommunicateBuffer, MmCommunicationConfiguration};
 use patina_sdk::component::{
     IntoComponent,
-    config::mm::{CommunicateBuffer, MmCommunicationConfiguration},
     hob::{FromHob, Hob},
     params::ConfigMut,
 };

--- a/src/q35/component/service/mm_control.rs
+++ b/src/q35/component/service/mm_control.rs
@@ -10,8 +10,8 @@
 //!
 #![cfg(all(target_os = "uefi", target_arch = "x86_64"))]
 
-use patina_sdk::component::config::mm::MmCommunicationConfiguration;
-use patina_sdk::component::service::platform_mm_control::PlatformMmControl;
+use patina_mm::config::MmCommunicationConfiguration;
+use patina_mm::service::platform_mm_control::PlatformMmControl;
 
 use crate::q35::registers as register;
 use patina_sdk::component::{IntoComponent, Storage, service::IntoService};

--- a/src/q35/component/service/mm_test.rs
+++ b/src/q35/component/service/mm_test.rs
@@ -10,10 +10,9 @@
 //! SPDX-License-Identifier: BSD-2-Clause-Patent
 //!
 
-use patina_sdk::component::service::mm_communicator::MmCommunication;
-use r_efi::efi;
-
+use patina_mm::service::MmCommunication;
 use patina_sdk::component::{IntoComponent, service::Service};
+use r_efi::efi;
 
 /// MM Supervisor Request Header
 ///


### PR DESCRIPTION
## Description

Updates the code for accessing the MM components, configs, and services via the `patina_mm` crate.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
- Build and boot Q35 to EFI shell and Windows

## Integration Instructions

N/A