### PR TITLE
MakeFile.toml: patch: Check for semver compliance

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -240,10 +240,10 @@ end
 if ${needs_patch}
     # Create a backup to revert to
     cp Cargo.toml Cargo.toml.bak
+    cp Cargo.lock Cargo.lock.bak
 
     # Patch the Cargo.toml file
     appendfile Cargo.toml ${patch_str}
-    exec cargo update
 end
 
 # Execute the actual cargo command
@@ -252,7 +252,7 @@ exit_code = exec --get-exit-code cargo make build-efi
 if ${needs_patch}
     # Revert the Cargo.toml file to the original state
     mv Cargo.toml.bak Cargo.toml
-    exec cargo update
+    mv Cargo.lock.bak Cargo.lock
 end
 
 exit ${exit_code}


### PR DESCRIPTION
## Description

Per the documentation regarding the [patch] option in the Cargo.toml file, the only thing that the [patch] option does is add that source to the list of sources Cargo will search for dependencies for. The dependency resolver still works the same way. Due to the fact that the dependency resolver is greedy, it will always choose the highest available version of a dependency.

To make patching more reliable, we add a check to our patch command to ensure that the patched crate's version is greater than or equal to the current version of the crate in the Cargo.lock file. This should help with the common issue of Cargo choosing a non-patched version of the crate, even when a patch is applied.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Verified that the tool returns an error if our patch version is less than the current version
- Verified that the tool does not complain when the patch version is equal to or greater than the current version
- In the limited testing, I never saw a patch rejected when the patch command did not fail early.

## Integration Instructions

N/A