### PR TITLE
QEMU: Release: Settings to optimize/reduce binary size by ~35%

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,15 @@ x86_64 = { version = "=0.15.2", default-features = false, features = [
   "instructions"
 ], optional = true }
 
+# These release settings reduce the qemu binary size significantly(~35%).
 [profile.release]
-debug = true
+codegen-units = 1
+debug = "full"
+lto = true
+opt-level = "s"
+split-debuginfo = "packed"
+strip = "symbols"
+incremental = true
 
 [profile.dev]
 opt-level = 3


### PR DESCRIPTION
## Description

Applying below release mode settings to optimize the qemu release binary size from **1162KB** to **762KB**(~35%). These settings were borrowed from [Microsoft Edit repo](https://github.com/microsoft/edit/blob/main/Cargo.toml#L20-L28)

Address: [#306](https://github.com/OpenDevicePartnership/patina/issues/306)

```
[profile.release]
codegen-units = 1
debug = "full"
lto = true
opt-level = "s"
split-debuginfo = "packed"
strip = "symbols"
incremental = true
```

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

`cargo make all`

## Integration Instructions

NA
