### PR TITLE
Makefile.toml: Allow Existing Patches in Cargo.toml for Patch Subcommand

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -181,10 +181,43 @@ if not is_empty ${1}
     end
 end
 
-needs_patch = not is_empty ${patch_repos}
+needs_patch = not array_is_empty ${patch_repos}
+patch_tag = set [patch.patina-fw]
 
 if ${needs_patch}
-    patch_str = concat "\n[patch.patina-fw]"
+    # Remove existing patch section from Cargo.toml
+    # Create a backup to revert to
+    cp Cargo.toml Cargo.toml.bak
+
+    # Read Cargo.toml lines
+    lines = readfile Cargo.toml
+    lines = split ${lines} "\n"
+    new_lines = array
+    in_patch = set false
+
+    for line in ${lines}
+        trimmed = trim ${line}
+        if starts_with ${trimmed} ${patch_tag}
+            in_patch = set true
+        else if ${in_patch}
+            if starts_with ${trimmed} "["
+                in_patch = set false
+            end
+        end
+        if not ${in_patch}
+            array_push ${new_lines} ${line}
+        end
+    end
+
+    # Write filtered lines back to Cargo.toml
+    write_lines = array_join ${new_lines} "\n"
+    writefile Cargo.toml ${write_lines}
+    release ${lines}
+    release ${new_lines}
+end
+
+if ${needs_patch}
+    patch_str = set ${patch_tag}
     for repo in ${patch_repos}
         echo "Processing repo: ${repo}"
         if not is_path_exists ${repo}/Cargo.toml
@@ -222,9 +255,6 @@ if ${needs_patch}
 end
 
 if ${needs_patch}
-    # Create a backup to revert to
-    cp Cargo.toml Cargo.toml.bak
-
     # Patch the Cargo.toml file
     appendfile Cargo.toml ${patch_str}
 end


### PR DESCRIPTION
## Description

Currently cargo make will fail if an existing cargo patch section exists when cargo make patch tries to apply another, because there are now two patch sections. This situation often occurs when the build process/qemu run is Ctrl-C'd out of, so the clean up step doesn't run, but it could have been manually written, too.

This commit updates cargo make patch to remove existing patch sections, write the user provided patches, build, then reapply the existing patches.

Other approaches considered were to
- restore a Cargo.toml.bak (created by cargo make patch) if it exists, but that was rejected because if the user has made other Cargo.toml edits since then, they would be lost
- parse the patch section and only apply the new crates to be patched that didn't already exist. This was rejected because the user may be wanting to change a patch location (say switching between two different local repos) and this would ignore what the user said. That could be made smarter but duckscript is not a place to do smart things

This also updates Cargo.lock while we are here.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Running the build and run script in patina-qemu with a local patch section in Cargo.toml and without.

## Integration Instructions

N/A.
