### PR TITLE
Make copyrights consistent

### DIFF
--- a/.nuget/license.txt
+++ b/.nuget/license.txt
@@ -1,1 +1,1 @@
-Copyright (c) Microsoft Corporation. All rights reserved.
+Copyright (c) Microsoft Corporation.

--- a/bin/q35_dxe_core.rs
+++ b/bin/q35_dxe_core.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!

--- a/bin/sbsa_dxe_core.rs
+++ b/bin/sbsa_dxe_core.rs
@@ -2,7 +2,7 @@
 //!
 //! ## License
 //!
-//! Copyright (C) Microsoft Corporation. All rights reserved.
+//! Copyright (c) Microsoft Corporation.
 //!
 //! SPDX-License-Identifier: Apache-2.0
 //!


### PR DESCRIPTION
## Description

Files had been added to the repo with a mix of Microsoft copyright format. The correct format is:

"Copyright (c) Microsoft Corporation."

Unrelated to the change, but the SPDX identifier is used so tools like GitHub license detection can parse the license.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

N/A