### PR TITLE
cspell: Update asm!(...); regex to support newlines

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -15,7 +15,7 @@ ignorePaths:
   - "**/book/**"
   - "**/contributors.md"
   - "docs/mermaid.min.js"
-ignoreRegExpList: ["/0x[0-9a-fA-F]+/", ".*asm!\\(.*?\\);"]
+ignoreRegExpList: ["/0x[0-9a-fA-F]+/", ".*asm!\\([\\s\\S]*?\\);"]
 minWordLength: 4
 caseSensitive: false
 allowCompoundWords: true
@@ -49,3 +49,4 @@ words:
   - webpki
   - zbuild
   - zunstable
+


### PR DESCRIPTION
## Description

The existing regex only matches if the entire `asm!(...);` macro is on the same line. The updated macro can now handle multi-line asm macros such as:

```rust
asm!(
   "...",
   "...",
);
```

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

ran `cargo make cspell` on code with a multi-line `asm!` macro and commands that would normally trigger a spell check did not.

## Integration Instructions

N/A
