### PR TITLE
v2.0.0: Integrate Patina v11.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,15 +340,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "patina_adv_logger"
-version = "9.0.0"
+name = "patina"
+version = "11.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "e1dce9ea0f4312f283a45139a6646788057592887481e6d2d502536474e96a55"
+checksum = "11a2817267823ef07db4a70579b770f9e1c78681690ba105567b93590c4e302d"
+dependencies = [
+ "cfg-if",
+ "fallible-streaming-iterator",
+ "fixedbitset",
+ "linkme",
+ "log",
+ "mu_pi",
+ "mu_rust_helpers",
+ "num-traits",
+ "patina_macro",
+ "r-efi",
+ "scroll",
+ "uart_16550",
+ "x86_64",
+]
+
+[[package]]
+name = "patina_adv_logger"
+version = "11.0.0"
+source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
+checksum = "32398153b5f1e953e9626668e4dfd76c914c0d713157fe2871c6e8ccfd0aeb3e"
 dependencies = [
  "log",
  "mu_pi",
  "mu_rust_helpers",
- "patina_sdk",
+ "patina",
  "r-efi",
  "spin",
  "zerocopy",
@@ -357,25 +378,25 @@ dependencies = [
 
 [[package]]
 name = "patina_debugger"
-version = "9.0.0"
+version = "11.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "468c318b24d4a9458419931070ec49e5198660ef4073f6349e79db59fe96feca"
+checksum = "25ce2816eef4a32c0521c60271c2519cadea7525e17da426a6d507f96602bff4"
 dependencies = [
  "bitfield-struct",
  "cfg-if",
  "gdbstub",
  "log",
+ "patina",
  "patina_internal_cpu",
  "patina_paging",
- "patina_sdk",
  "spin",
 ]
 
 [[package]]
 name = "patina_dxe_core"
-version = "9.0.0"
+version = "11.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "94f32b41f70f752f88cbefe7422e3ca4bb0c3ad8caefbec971aaffb1e5749d41"
+checksum = "f997ea1249f9d926403e0ac29e2d97812fae19b75c094acc2442234fa98b3572"
 dependencies = [
  "arm-gic",
  "cfg-if",
@@ -387,6 +408,7 @@ dependencies = [
  "log",
  "mu_pi",
  "mu_rust_helpers",
+ "patina",
  "patina_debugger",
  "patina_ffs",
  "patina_internal_collections",
@@ -395,7 +417,6 @@ dependencies = [
  "patina_internal_device_path",
  "patina_paging",
  "patina_performance",
- "patina_sdk",
  "r-efi",
  "scroll",
  "spin",
@@ -405,56 +426,56 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs"
-version = "9.0.0"
+version = "11.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "1641cb64418548e1750adb0810d30b49bb4094db650774ecba3e51bd470f9a07"
+checksum = "2a2621ff01279348a989ad31435bfb611204888ec377201d511d5e6f7bc22397"
 dependencies = [
  "log",
  "mu_pi",
- "patina_sdk",
+ "patina",
  "r-efi",
 ]
 
 [[package]]
 name = "patina_ffs_extractors"
-version = "9.0.0"
+version = "11.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "9ce3ef41184e3c9d2bae6ffbcfd3502bc4a5be1132a986a165357b8cb347392e"
+checksum = "99f4a160310d650283bfa9dc25ffb62f6e0cef918bb95a39e41b88da4346beed"
 dependencies = [
  "alloc-no-stdlib",
  "brotli-decompressor",
  "crc32fast",
  "log",
  "mu_pi",
+ "patina",
  "patina_ffs",
  "patina_lzma_rs",
- "patina_sdk",
  "r-efi",
 ]
 
 [[package]]
 name = "patina_internal_collections"
-version = "9.0.0"
+version = "11.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "d26cc2a871d46531f987ab80fa3b9105b90d08aec7123bddd2d05a6bfbcdb21a"
+checksum = "a1c6345ba7003483d59527217b49ed745179fb5e02e16e1f609b7817fa28646f"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "patina_internal_cpu"
-version = "9.0.0"
+version = "11.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "85c18adcc4281910bc2c6f58ef7321814458af2e34a8d7f5035cb864bea3b217"
+checksum = "e137dc1de9a3891e4eab9fc98b317666fdebab9b4d328c90976c7165db0ce253"
 dependencies = [
  "arm-gic",
  "cfg-if",
  "lazy_static",
  "log",
  "mu_pi",
+ "patina",
  "patina_mtrr",
  "patina_paging",
- "patina_sdk",
  "patina_stacktrace",
  "r-efi",
  "safe-mmio",
@@ -464,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_depex"
-version = "9.0.0"
+version = "11.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "d5266bad82ab563f6c1939c1be117ce3901e2a82eb3e159e4c1bda6d696e2fbf"
+checksum = "2dd8386e7ea7df746e4a3581fdf5ef59c6c6a96a61d14da5c56b1d224e83b4af"
 dependencies = [
  "log",
  "r-efi",
@@ -475,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_device_path"
-version = "9.0.0"
+version = "11.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "6140291618b6ab56b26278fdd1bd3d9628c1c9e6c384cd878336449b46be2651"
+checksum = "1030051b96b34806c453aeafc9c854e9e759f5a492dc9821becfe9e663a8bab8"
 dependencies = [
  "log",
  "r-efi",
@@ -495,14 +516,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "patina_mm"
-version = "9.0.0"
+name = "patina_macro"
+version = "11.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "62e307462165698105c38d6f554e6e6e0154275a056270977959dca2642ae14f"
+checksum = "8264d205223dc6fa11cf4f65eef65e790670cc5de466e710b76434fdeb083889"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "uuid",
+]
+
+[[package]]
+name = "patina_mm"
+version = "11.0.0"
+source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
+checksum = "382f7b54f2589d783b74309f01f6365c926fdbb176b7c1b6e68c6549b7235810"
 dependencies = [
  "cfg-if",
  "log",
- "patina_sdk",
+ "patina",
  "r-efi",
  "x86_64",
 ]
@@ -531,15 +564,15 @@ dependencies = [
 
 [[package]]
 name = "patina_performance"
-version = "9.0.0"
+version = "11.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "b40dcc214bc49c48241668df2d83dab75de9acc9124a9a06c3a34e3fb6c341f9"
+checksum = "25562bf035d637f17a0d3867836088e8474d050a993b74f7988621c73f7cfbf4"
 dependencies = [
  "log",
  "mu_pi",
  "mu_rust_helpers",
+ "patina",
  "patina_internal_device_path",
- "patina_sdk",
  "r-efi",
  "scroll",
  "uuid",
@@ -547,52 +580,19 @@ dependencies = [
 
 [[package]]
 name = "patina_samples"
-version = "9.0.0"
+version = "11.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "e089d5e22659ea59ec9fc61086b7b8cf562a6e1017a3af4d8886771737916ae2"
+checksum = "2a4425cf03198382bb80270246e0d1b23231c483f03a284a410d35cab413af69"
 dependencies = [
  "log",
- "patina_sdk",
-]
-
-[[package]]
-name = "patina_sdk"
-version = "9.0.0"
-source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "7d5704f65904ae2dffef536703b66fd603988ed29f9425abfd81bd396f222e8b"
-dependencies = [
- "cfg-if",
- "fallible-streaming-iterator",
- "fixedbitset",
- "linkme",
- "log",
- "mu_pi",
- "mu_rust_helpers",
- "num-traits",
- "patina_sdk_macro",
- "r-efi",
- "scroll",
- "uart_16550",
- "x86_64",
-]
-
-[[package]]
-name = "patina_sdk_macro"
-version = "9.0.0"
-source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "7aa5cc7dfa9241d17249b9a371667795e5ef40ec1685dcf14af73f376c313114"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "uuid",
+ "patina",
 ]
 
 [[package]]
 name = "patina_stacktrace"
-version = "9.0.0"
+version = "11.0.0"
 source = "sparse+https://pkgs.dev.azure.com/patina-fw/artifacts/_packaging/temporary/Cargo/index/"
-checksum = "08bca9fb33e33a588a7a2d43913e09c5dd82f1ef8bee2aa26dd695976b2edab9"
+checksum = "32d61ea7a70fdc9b83933454103da72a8c798a18c6776a9f0bc8480e75878e80"
 dependencies = [
  "cfg-if",
  "log",
@@ -621,9 +621,10 @@ dependencies = [
 
 [[package]]
 name = "qemu_dxe_core"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "log",
+ "patina",
  "patina_adv_logger",
  "patina_debugger",
  "patina_dxe_core",
@@ -631,7 +632,6 @@ dependencies = [
  "patina_mm",
  "patina_performance",
  "patina_samples",
- "patina_sdk",
  "patina_stacktrace",
  "r-efi",
  "x86_64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qemu_dxe_core"
-version = "1.0.1"
+version = "2.0.0"
 edition = "2024"
 license = "Apache-2.0"
 
@@ -22,15 +22,15 @@ path = "src/lib.rs"
 log = { version = "^0.4", default-features = false, features = [
     "release_max_level_warn",
 ] }
-patina_adv_logger = { version = "9", registry = "patina-fw" }
-patina_debugger = { version = "9", registry = "patina-fw" }
-patina_dxe_core = { version = "9", registry = "patina-fw" }
-patina_mm = { version = "9", registry = "patina-fw" }
-patina_performance = { version = "9", registry = "patina-fw"}
-patina_samples = { version = "9", registry = "patina-fw" }
-patina_sdk = { version = "9", registry = "patina-fw", features = ["enable_patina_tests"] }
-patina_ffs_extractors = { version = "9", registry = "patina-fw" }
-patina_stacktrace = { version = "9", registry = "patina-fw" }
+patina_adv_logger = { version = "11", registry = "patina-fw" }
+patina_debugger = { version = "11", registry = "patina-fw" }
+patina_dxe_core = { version = "11", registry = "patina-fw" }
+patina_mm = { version = "11", registry = "patina-fw" }
+patina_performance = { version = "11", registry = "patina-fw"}
+patina_samples = { version = "11", registry = "patina-fw" }
+patina = { version = "11", registry = "patina-fw", features = ["enable_patina_tests"] }
+patina_ffs_extractors = { version = "11", registry = "patina-fw" }
+patina_stacktrace = { version = "11", registry = "patina-fw" }
 r-efi = { version = "^5", default-features = false }
 x86_64 = { version = "=0.15.2", default-features = false, features = [
   "instructions"

--- a/bin/q35_dxe_core.rs
+++ b/bin/q35_dxe_core.rs
@@ -11,10 +11,10 @@
 #![no_main]
 
 use core::{ffi::c_void, panic::PanicInfo};
+use patina::{log::Format, serial::uart::Uart16550};
 use patina_adv_logger::{component::AdvancedLoggerComponent, logger::AdvancedLogger};
 use patina_dxe_core::Core;
 use patina_samples as sc;
-use patina_sdk::{log::Format, serial::uart::Uart16550};
 use patina_stacktrace::StackTrace;
 use qemu_resources::q35::component::service as q35_services;
 extern crate alloc;
@@ -64,10 +64,8 @@ pub extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
 
     Core::default()
         .init_memory(physical_hob_list) // We can make allocations now!
-        .with_config(sc::Name("World")) // Config knob for sc::log_hello
         .with_service(patina_ffs_extractors::CompositeSectionExtractor::default())
         .with_component(adv_logger_component)
-        .with_component(sc::log_hello) // Example of a function component
         .with_component(sc::HelloStruct("World")) // Example of a struct component
         .with_component(sc::GreetingsEnum::Hello("World")) // Example of a struct component (enum)
         .with_component(sc::GreetingsEnum::Goodbye("World")) // Example of a struct component (enum)
@@ -85,11 +83,11 @@ pub extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
         .with_config(patina_performance::config::PerfConfig {
             enable_component: true,
             enabled_measurements: {
-                patina_sdk::performance::Measurement::DriverBindingStart         // Adds driver binding start measurements.
-               | patina_sdk::performance::Measurement::DriverBindingStop        // Adds driver binding stop measurements.
-               | patina_sdk::performance::Measurement::DriverBindingSupport     // Adds driver binding support measurements.
-               | patina_sdk::performance::Measurement::LoadImage                // Adds load image measurements.
-               | patina_sdk::performance::Measurement::StartImage // Adds start image measurements.
+                patina::performance::Measurement::DriverBindingStart         // Adds driver binding start measurements.
+               | patina::performance::Measurement::DriverBindingStop        // Adds driver binding stop measurements.
+               | patina::performance::Measurement::DriverBindingSupport     // Adds driver binding support measurements.
+               | patina::performance::Measurement::LoadImage                // Adds load image measurements.
+               | patina::performance::Measurement::StartImage // Adds start image measurements.
             },
         })
         .with_component(patina_performance::component::performance_config_provider::PerformanceConfigurationProvider)

--- a/bin/sbsa_dxe_core.rs
+++ b/bin/sbsa_dxe_core.rs
@@ -11,10 +11,9 @@
 #![no_main]
 
 use core::{ffi::c_void, panic::PanicInfo};
+use patina::{log::Format, serial::uart::UartPl011};
 use patina_adv_logger::{component::AdvancedLoggerComponent, logger::AdvancedLogger};
 use patina_dxe_core::{Core, GicBases};
-use patina_samples as sc;
-use patina_sdk::{log::Format, serial::uart::UartPl011};
 use patina_stacktrace::StackTrace;
 
 #[panic_handler]
@@ -60,13 +59,8 @@ pub extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
     Core::default()
         .init_memory(physical_hob_list) // We can make allocations now!
         .with_config(GicBases::new(0x40060000, 0x40080000)) // GIC bases for AArch64
-        .with_config(sc::Name("World")) // Config knob for sc::log_hello
         .with_service(patina_ffs_extractors::CompositeSectionExtractor::default())
         .with_component(adv_logger_component)
-        .with_component(sc::log_hello) // Example of a function component
-        .with_component(sc::HelloStruct("World")) // Example of a struct component
-        .with_component(sc::GreetingsEnum::Hello("World")) // Example of a struct component (enum)
-        .with_component(sc::GreetingsEnum::Goodbye("World")) // Example of a struct component (enum)
         .start()
         .unwrap();
 

--- a/src/q35/component/service/mm_config_provider.rs
+++ b/src/q35/component/service/mm_config_provider.rs
@@ -9,12 +9,12 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-use patina_mm::config::{CommunicateBuffer, MmCommunicationConfiguration};
-use patina_sdk::component::{
+use patina::component::{
     IntoComponent,
     hob::{FromHob, Hob},
     params::ConfigMut,
 };
+use patina_mm::config::{CommunicateBuffer, MmCommunicationConfiguration};
 
 use crate::q35::registers as register;
 
@@ -48,7 +48,7 @@ impl MmConfigurationProvider {
     /// Depends on at least one instance of the MM Communicate Region HOB to be present in the HOB list. This component
     /// will not be dispatched if no MM Communicate Region HOBs are present in the HOB list.
     ///
-    /// Depends on a mutable `patina_sdk::component::config::mm::MmCommunicationConfiguration` instance to be in storage. This
+    /// Depends on a mutable `patina::component::config::mm::MmCommunicationConfiguration` instance to be in storage. This
     /// component will populate the given configuration instance with runtime information about the MM configuration
     /// and lock the configuration to prevent further modifications and to allow components with immutable dependencies
     /// on the configuration to be dispatched.
@@ -62,19 +62,19 @@ impl MmConfigurationProvider {
     /// ## Returns
     ///
     /// - `Ok(())` if the entry point was successful.
-    /// - `Err(patina_sdk::error::Result)` if the entry point failed.
+    /// - `Err(patina::error::Result)` if the entry point failed.
     ///
     pub fn entry_point(
         self,
         mm_comm_region_hob: Hob<MmCommRegionHob>,
         mut config_mut: ConfigMut<MmCommunicationConfiguration>,
-    ) -> patina_sdk::error::Result<()> {
+    ) -> patina::error::Result<()> {
         log::debug!("MM Configuration Provider Entry Point");
 
         log::debug!("Incoming MM Configuration: {config_mut:?}");
 
         let pm_base: *const u16 = (register::PCI_EXPRESS_BASE_ADDRESS as usize
-            + patina_sdk::pci_address!(0, 0x1F, 0, register::ich9::PMBASE) as usize)
+            + patina::pci_address!(0, 0x1F, 0, register::ich9::PMBASE) as usize)
             as *const u16;
         let pm_base_value: u16 = unsafe { core::ptr::read_volatile(pm_base) } & register::ich9::PMBASE_MASK;
 
@@ -93,7 +93,7 @@ impl MmConfigurationProvider {
             unsafe {
                 config_mut.comm_buffers.push(CommunicateBuffer::from_raw_parts(
                     hob.address as usize as *mut u8,
-                    hob.pages as usize * patina_sdk::base::UEFI_PAGE_SIZE,
+                    hob.pages as usize * patina::base::UEFI_PAGE_SIZE,
                     hob.buffer_type as u8,
                 ));
             }

--- a/src/q35/component/service/mm_control.rs
+++ b/src/q35/component/service/mm_control.rs
@@ -14,7 +14,7 @@ use patina_mm::config::MmCommunicationConfiguration;
 use patina_mm::service::platform_mm_control::PlatformMmControl;
 
 use crate::q35::registers as register;
-use patina_sdk::component::{IntoComponent, Storage, service::IntoService};
+use patina::component::{IntoComponent, Storage, service::IntoService};
 
 use x86_64::instructions::port::Port;
 
@@ -41,7 +41,7 @@ impl QemuQ35PlatformMmControl {
     ///
     /// Installs an instance of the `PlatformMmControl` service that can be invoked by other components that depend
     /// upon hardware initialization for MMI control.
-    pub fn entry_point(mut self, storage: &mut Storage) -> patina_sdk::error::Result<()> {
+    pub fn entry_point(mut self, storage: &mut Storage) -> patina::error::Result<()> {
         log::debug!("Platform MM Control Entry Point");
 
         self.inner_config = storage
@@ -60,7 +60,7 @@ impl PlatformMmControl for QemuQ35PlatformMmControl {
     /// Initializes QEMU Q35 for Management Mode (MM).
     ///
     /// After this function completes, the platform hardware enabling required to support MMIs is completed.
-    fn init(&self) -> patina_sdk::error::Result<()> {
+    fn init(&self) -> patina::error::Result<()> {
         log::debug!("Performing platform-specific MM init...");
 
         let mut smi_en_port =
@@ -82,7 +82,7 @@ impl PlatformMmControl for QemuQ35PlatformMmControl {
 
         // Set the SMI Lock bit in the PM1A_CNT register to lock the SMI_EN bits
         let pm1a_cnt: *mut u16 = (register::PCI_EXPRESS_BASE_ADDRESS as usize
-            + patina_sdk::pci_address!(0, 0x1F, 0, register::ich9::GEN_PMCON_1) as usize)
+            + patina::pci_address!(0, 0x1F, 0, register::ich9::GEN_PMCON_1) as usize)
             as *mut u16;
         let mut pm1a_cnt_val: u16 = unsafe { core::ptr::read_volatile(pm1a_cnt) };
         pm1a_cnt_val |= register::ich9::GEN_PMCON_1_SMI_LOCK;

--- a/src/q35/component/service/mm_test.rs
+++ b/src/q35/component/service/mm_test.rs
@@ -10,8 +10,8 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
+use patina::component::{IntoComponent, service::Service};
 use patina_mm::service::MmCommunication;
-use patina_sdk::component::{IntoComponent, service::Service};
 use r_efi::efi;
 
 /// MM Supervisor Request Header
@@ -60,7 +60,7 @@ impl QemuQ35MmTest {
     ///
     /// Uses the `MmCommunication` service to send a request version information from the MM Supervisor. The MM
     /// Supervisor is expected to be the Standalone MM environment used on the QEMU Q35 platform.
-    pub fn entry_point(self, mm_comm: Service<dyn MmCommunication>) -> patina_sdk::error::Result<()> {
+    pub fn entry_point(self, mm_comm: Service<dyn MmCommunication>) -> patina::error::Result<()> {
         log::debug!("MM Test Entry Point - Testing MM Communication");
 
         let mm_supv_req_header = MmSupervisorRequestHeader {
@@ -90,7 +90,7 @@ impl QemuQ35MmTest {
                 )
                 .map_err(|_| {
                     log::error!("MM Communication failed");
-                    patina_sdk::error::EfiError::DeviceError // Todo: Map actual codes
+                    patina::error::EfiError::DeviceError // Todo: Map actual codes
                 })?
         };
 


### PR DESCRIPTION
## Description

Makes integration changes needed for Patina 11.0.0. Mainly:

1. Refactor `patina_sdk` references to `patina`
2. Drop component example in DXE Core init

Major version is bumped to signify to platforms that the C RuntimeDxe driver is needed with this release.

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
- QEMU platform integration (PR will come there to integrate this after this release is made).

## Integration Instructions

- Include the C `RuntimeDxe` driver in the platform firmware image