### PR TITLE
q35: Disable MM Comm until supv services are available

### DIFF
--- a/bin/q35_dxe_core.rs
+++ b/bin/q35_dxe_core.rs
@@ -68,7 +68,7 @@ pub extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
         .with_component(adv_logger_component)
         .with_component(sc::HelloStruct("World")) // Example of a struct component
         .with_component(sc::GreetingsEnum::Hello("World")) // Example of a struct component (enum)
-        .with_component(sc::GreetingsEnum::Goodbye("World")) // Example of a struct component (enum)
+        .with_component(sc::GreetingsEnum::Goodbye("World")) // Example of a struct component (enum)0
         .with_config(patina_mm::config::MmCommunicationConfiguration {
             acpi_base: patina_mm::config::AcpiBase::Mmio(0x0), // Actual ACPI base address will be set during boot
             cmd_port: patina_mm::config::MmiPort::Smi(0xB2),
@@ -78,8 +78,14 @@ pub extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
         .with_component(q35_services::mm_config_provider::MmConfigurationProvider)
         .with_component(q35_services::mm_control::QemuQ35PlatformMmControl::new())
         .with_component(patina_mm::component::sw_mmi_manager::SwMmiManager::new())
-        .with_component(patina_mm::component::communicator::MmCommunicator::new())
-        .with_component(q35_services::mm_test::QemuQ35MmTest::new())
+        // The Q35 firmware using the MM Supervisor. Additional support is needeed in the
+        // supervisor to support MM communication outside of code that has direct access
+        // to C internal state.
+        //
+        // Tracked in https://github.com/microsoft/mu_feature_mm_supv/issues/541
+        //
+        // .with_component(patina_mm::component::communicator::MmCommunicator::new())
+        // .with_component(q35_services::mm_test::QemuQ35MmTest::new())
         .with_config(patina_performance::config::PerfConfig {
             enable_component: true,
             enabled_measurements: {


### PR DESCRIPTION
## Description

Disables `MmCommunicator` and `QemuQ35MmTest` for the reasons mentioned in the code comment. Reenabling is mostly dependent on the following MM Supervisor issue being completed:

https://github.com/microsoft/mu_feature_mm_supv/issues/541

> I'm going to add a host-based MM handler simulator in Patina to cover testing while this is removed from this binary. That will also technically test the MM Communication more thoroughly than this code long-term.

Reenabling tracked in https://github.com/OpenDevicePartnership/patina-dxe-core-qemu/issues/42

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all` in this repo
- QEMU Q35 boot with `BLD_*_PERF_TRACE_ENABLE` set to `TRUE` and `FALSE`

Period of component dispatch with these removed:

```
.  .  .
INFO - ACPI I/O Port Address: 0xB00F8040
INFO - ACPI (PMBASE) I/O Port: 0x600
INFO - Found 2 MM Communicate Region HOBs
INFO - Dispatched: Id = ["qemu_resources::q35::component::service::mm_config_provider::MmConfigurationProvider"] Status = [Success]
INFO - Dispatched: Id = ["qemu_resources::q35::component::service::mm_control::QemuQ35PlatformMmControl"] Status = [Success]
INFO - Dispatched: Id = ["patina_mm::component::sw_mmi_manager::SwMmiManager"] Status = [Success]
INFO - Dispatched: Id = ["patina_performance::component::performance_config_provider::PerformanceConfigurationProvider"] Status = [Success]
INFO - Performance: 74 Hob performance records found.
INFO - InstallProtocolInterface: C85D06BE-5F75-48CE-A80F-1236BA3B87B1 @ 0x000000007e566620
INFO - Dispatched: Id = ["patina_performance::component::performance::Performance"] Status = [Success]
INFO - Depex evaluation complete, scheduled 2 drivers
.  .  .
```

## Integration Instructions

- N/A - The components will no longer be loaded in the Patina Intel Q35 binary.