### PR TITLE
Fix Crate Patch on Linux

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -238,7 +238,13 @@ if ${needs_patch}
             name = map_get ${package} name
             path = map_get ${package} id
 
-            path = replace ${path} "path+file:///" ""
+            # Unfortunately, the path formats are different between Windows and Linux environments
+            # path+file:// is added to Linux paths and path+file:/// is added to Windows paths
+            if is_windows
+                path = replace ${path} "path+file:///" ""
+            else
+                path = replace ${path} "path+file://" ""
+            end
             temp = split ${path} "#"
             path = array_get ${temp} 0
 


### PR DESCRIPTION
## Description

The crate patch duckscript was assuming that all paths returned by cargo-metadata were getting `path+file:///` prepended and so stripping it to get to the real path. However, this is only true on Windows. On Linux, only `path+file://` is prepended. When the extra slash is removed on Linux, the patch fails because now the root dir is removed and the repo can't be found.

e.g. Windows paths come in looking like `path+file:///d:/r/patina` and Linux paths come in looking like `path+file:///workspaces/patina`. Note that Linux does have three slashes, but the last one is actually part of the path (the repo living at /workspaces/patina).

This updates the duckscript to strip by OS accordingly.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested running crate patches on Windows and Linux with full and relative paths.

## Integration Instructions

N/A.
