### PR TITLE
Use opt-level "s" for dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ strip = "symbols"
 incremental = true
 
 [profile.dev]
-opt-level = 3
+opt-level = "s"
 
 [profile.test]
 opt-level = 0


### PR DESCRIPTION
## Description

The release profile already uses "s" optimization level, which is optimized for size. We are running low on space for dev builds in the patch and it doesn't make sense to optimize for speed on the dev builds if we are not doing so for release builds.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Boot to OS on Q35

## Integration Instructions

N/A
