### PR TITLE
QEMU: Make PDB path/name deterministic

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,27 +6,7 @@ rustflags = [
     "-C", "link-arg=/base:0x0",
     "-C", "link-arg=/subsystem:efi_boot_service_driver",
     "-C", "force-unwind-tables", # Generates .pdata section for stack tracing
-    # Starting with rustc 1.78 and later, the compiler (rustc) will
-    # automatically pass the flag /PDBALTPATH:%_PDB% to the linker (rust-lld).
-    # Note that %_PDB% is not read from the environment; instead, The linker
-    # will replace %_PDB% with the base name of the module being linked. This is
-    # not the desired behavior for us as it can break WinDBG in multiple ways,
-    # as we need the full path to the PDB file. Fortunately, if the flag exists
-    # but is empty, LLD will populate it with the full path of the PDB file.
-    #
-    # Ref:
-    # https://github.com/rust-lang/rust/pull/121297
-    # https://github.com/rust-lang/rust/blob/75530e9f72a1990ed2305e16fd51d02f47048f12/compiler/rustc_codegen_ssa/src/back/linker.rs#L1049-L1056
-    # https://github.com/llvm/llvm-project/blob/9ed772cecc23f5f5b060720399b010275bbb7457/lld/COFF/Driver.cpp#L2433-L2446
-    "-C", "link-arg=/PDBALTPATH:",
-]
-
-[target.i686-unknown-uefi]
-rustflags = [
-    "-C", "link-arg=/base:0x0",
-    "-C", "link-arg=/subsystem:efi_boot_service_driver",
-    "-C", "force-unwind-tables", # Generates .pdata section for stack tracing
-    "-C", "link-arg=/PDBALTPATH:",
+    "-C", "link-arg=/PDBALTPATH:qemu_q35_dxe_core.pdb",
 ]
 
 [target.aarch64-unknown-uefi]
@@ -34,5 +14,5 @@ rustflags = [
     "-C", "link-arg=/base:0x0",
     "-C", "link-arg=/subsystem:efi_boot_service_driver",
     "-C", "force-unwind-tables", # Generates .pdata section for stack tracing
-    "-C", "link-arg=/PDBALTPATH:",
+    "-C", "link-arg=/PDBALTPATH:qemu_sbsa_dxe_core.pdb",
 ]


### PR DESCRIPTION
## Description

Explicitly specifying the PDB name via `PDBALTPATH` improves debugger usability for several reasons:

1. Cargo copies the final `.efi` and its `.pdb` to `target\<target-triple>\[debug|release]` as `qemu_sbsa_dxe_core.efi`(no hash appended.
2. Full paths embedded in the efi generated on WSL make it harder for the debugger to map the `.efi` to the `.pdb` on Windows.
3. Without this PR, the PDB file name is non-deterministic (it includes a hash), even though it contains the full path, making debugging/scripting tedious.
4. As long as the `.efi` and `.pdb` files are in the same directory, WinDbg can easily pick up the PDB file without any manual fixes.
5. Even if they are not in the same directory, `.sympath+` can be used to point WinDbg to the directory containing the pdb files.

Since WinDbg checks the current directory for the PDB by default, based on the path embedded in the .efi, providing just the file name (not the full path) for PDBALTPATH allows the debugger to locate it easily without requiring any file renames.

```
Option 1: Without the PDBALTPATH option
Debug Directories(1)
    Type       Size     Address  Pointer
    cv           3f      1b1074   1afa74    Format: RSDS, guid, 1, qemu_sbsa_dxe_core-b3e9a890bb6be3ce.pdb

Option 2: -C link-arg=/PDBALTPATH:%_PDB% # This is the default behaviour by rustc.
Debug Directories(1)
    Type       Size     Address  Pointer
    cv           3f      1b1074   1afa74    Format: RSDS, guid, 1, qemu_sbsa_dxe_core-f3080c9eaed3fe01.pdb

Option 3: -C link-arg=/PDBALTPATH: # only useful on Windows, that too, only if the path exists(not useful for remote/offline debugging)
Debug Directories(1)
    Type       Size     Address  Pointer
    cv           83      1b1074   1afa74    Format: RSDS, guid, 1, E:\repos\patina-dxe-core-qemu\target\aarch64-unknown-uefi\debug\deps\qemu_sbsa_dxe_core-765fdbf691f03726.pdb

Option 4: -C link-arg=/PDBALTPATH:qemu_sbsa_dxe_core.pdb
Debug Directories(1)
    Type       Size     Address  Pointer
    cv           2e      1b1074   1afa74    Format: RSDS, guid, 1, qemu_sbsa_dxe_core.pdb
```

Fixes [#445](https://github.com/OpenDevicePartnership/patina/issues/445)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Validated on QEMU

## Integration Instructions
Other platform specific rust dxe binaries need to incorporate a similar change to achieve a better debugging experience!