### PR TITLE
Makefile.toml: Add `--leave-patch` argument

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -184,6 +184,7 @@ script = '''
 
 # Find all arguments after --crate-patch and collect them
 patch_repos = array
+leave_patch = set false
 if not is_empty ${1}
     args = split ${1} ";"
     found_patch_flag = set false
@@ -191,6 +192,8 @@ if not is_empty ${1}
         arg = trim ${arg}
         if eq ${arg} "--crate-patch"
             found_patch_flag = set true
+        elseif eq ${arg} "--leave-patch"
+            leave_patch = set true
         elseif ${found_patch_flag}
             array_push ${patch_repos} ${arg}
             found_patch_flag = set false
@@ -286,8 +289,13 @@ end
 cm_run_task build-efi
 
 if ${needs_patch}
-    # Revert the Cargo.toml file to the original state
-    mv Cargo.toml.bak Cargo.toml
+    if not ${leave_patch}
+        # Revert the Cargo.toml file to the original state
+        mv Cargo.toml.bak Cargo.toml
+    else
+        # Remove the backup since we're leaving the patch
+        rm Cargo.toml.bak
+    end
 end
 
 exit 0

--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ built by default on debug builds, but not release builds. It can be built on rel
 `build_debugger` feature to the build, e.g. `cargo make q35-release --features build_debugger`. The debugger
 is disabled by default, passing the `enable_debugger` feature to the build will enable it.
 
+## Patching Local Dependencies
+
+During development, you may need to build against local versions of Patina crates. This repo's build supports patching
+dependencies using the `--crate-patch` argument. By default, patches are automatically removed after building, but you
+can keep them using the `--leave-patch` flag.
+
+| Use Case | Command | Result |
+|----------|---------|--------|
+| Build with local Patina crates | `cargo make q35 -- --crate-patch c:\src\patina\` | Patches, builds, & reverts patch |
+| Build and keep patch | `cargo make q35 -- --crate-patch c:\src\patina\ --leave-patch` | Patches, builds, keeps patch |
+| Multiple repositories | `cargo make q35 -- --crate-patch c:\path1\ --crate-patch c:\path2\` | Patches multiple repos |
+
+The `--crate-patch` argument works with any build target (`q35`, `q35-release`, `sbsa`, `sbsa-release`).
+
 ## Size Comparison
 
 The code in both the C and Rust modules is always changing and depending on the compression algorithm used, size comparisons


### PR DESCRIPTION
## Description

1. Add a `--leave-patch` argument that will not automatically revert the patch section in Cargo.toml when `--crate-patch` is used.
2. Add `--crate-patch` documentation to the readme.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- Using the commands mentioned in the readme addition.

## Integration Instructions

- N/A

---

My use case for `--leave-patch` is to conveniently have the patch section generated for a local `patina` repo and then copy the section to another Patina DXE Core build Cargo.toml file (that might not have patch capability).