### PR TITLE
Update to Patina v15.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,16 @@ version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a21cd0131c25c438e19cd6a774adf7e3f64f7f4d723022882facc2dee0f8bc9"
 dependencies = [
- "tock-registers",
+ "tock-registers 0.9.0",
+]
+
+[[package]]
+name = "aarch64-cpu"
+version = "11.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2902b1d87157187000598c0dfc24f438b01792bc10d257c671bd65e24f4b5878"
+dependencies = [
+ "tock-registers 0.10.1",
 ]
 
 [[package]]
@@ -19,9 +28,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "arm-gic"
-version = "0.5.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527b6e1c87b792f272e4964bef31a852077c35a395085833c8b51dc0ef3b4e13"
+checksum = "fc8a5b06c02f993e98b0b3eb95c3acefb6889cc33a630621fb3e6c564502c2b0"
 dependencies = [
  "bitflags 2.10.0",
  "safe-mmio",
@@ -298,7 +307,7 @@ version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df471d72676adaa480d61a0c9ed30a844a90842f876c188a0b30cb760d2444aa"
 dependencies = [
- "aarch64-cpu",
+ "aarch64-cpu 10.0.0",
  "log",
 ]
 
@@ -331,9 +340,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "patina"
-version = "14.3.2"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b61a1f3faf9f6891326d8221df9d89e125a370b219549abe6ae2b0d3a8c3cd"
+checksum = "9043d0e24ef5412c1a8fe0fd7323c847a49f89e2eb1e17bab8d842a116fe90b7"
 dependencies = [
  "cfg-if",
  "fallible-streaming-iterator",
@@ -346,6 +355,7 @@ dependencies = [
  "patina_macro",
  "r-efi",
  "scroll",
+ "spin",
  "uart_16550",
  "uuid",
  "x86_64",
@@ -355,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "patina_adv_logger"
-version = "14.3.2"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b74c81aef213815f24f4484a55766fe446c1adf62c95da53193940b37d44e83"
+checksum = "0d99373f0945f8172ca82048cc44590bb799b43363838525cf70e8d4ca9248d0"
 dependencies = [
  "log",
  "mu_rust_helpers",
@@ -370,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "patina_debugger"
-version = "14.3.2"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e819b676aba2387d92918dff8e5a8973e649cf6e95e62ad1cd7e66837ae4d5e"
+checksum = "6c9b251294952460639928d027349202c9fb2535039e113f0e1ff26562318efc"
 dependencies = [
  "bitfield-struct",
  "cfg-if",
@@ -380,16 +390,18 @@ dependencies = [
  "log",
  "patina",
  "patina_internal_cpu",
+ "patina_mtrr",
  "patina_paging",
  "spin",
 ]
 
 [[package]]
 name = "patina_dxe_core"
-version = "14.3.2"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f46d66ba13c8734dcb9e36beff67e66b1d815def818debfc1e8f0e4f2ed4d8"
+checksum = "9e540eddf418ceecf75b4da4003f3047133c75bd403dc5b5eb6a72a0fbc67a15"
 dependencies = [
+ "aarch64-cpu 11.1.0",
  "arm-gic",
  "cfg-if",
  "compile-time",
@@ -417,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs"
-version = "14.3.2"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb468c3cf5e803db760d763752c6070d8ff139fe87cb1ff06aeaeccba3f7a5b"
+checksum = "a1fadc7183885e3cd70e94996b816e47d5d102a9187f77cd85a5cc5b30fdbff8"
 dependencies = [
  "log",
  "patina",
@@ -428,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs_extractors"
-version = "14.3.2"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ae3b40fd87f10841ec12128dcf75c1db2de29d91804d4fab94f49f7cef87553"
+checksum = "0cda0d9dd4887674acb65940d77beea541d3168bc0f8b368425d21e30760ddff"
 dependencies = [
  "alloc-no-stdlib",
  "brotli-decompressor",
@@ -444,18 +456,18 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_collections"
-version = "14.3.2"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b72c070e4cd4d58e55400437a69d43a6f24ad99daccf4fc5615e433819cb6"
+checksum = "2bf6e3696dd83bb7e812c6aeaf7849a148daaf31bac4c4a61680c56fcf442961"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "patina_internal_cpu"
-version = "14.3.2"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1284493d70284b99856717744d37e704675dff05b02640e5ca3450a57b8c3300"
+checksum = "ea7ac7de432235dcea09c077f60d4460f510690f68a99f606de325e8bbf66cca"
 dependencies = [
  "arm-gic",
  "cfg-if",
@@ -473,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_depex"
-version = "14.3.2"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72334fad8836a79a7c943a39d33b5964d981ef4485b6284d5c76f92f20bc0cbc"
+checksum = "b2707b91204821a9297744dd9194dbf782e7289bcf0f23986333973684d11cd7"
 dependencies = [
  "log",
  "r-efi",
@@ -484,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_device_path"
-version = "14.3.2"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f18e38a5852a03c1f01b6a57d8051a277d970ff5ec6f4028bd3e25467f25125"
+checksum = "f2491eea5dfd10e4654b36e5097639ab3ba73e2850271040bfa2cff14f33562f"
 dependencies = [
  "log",
  "r-efi",
@@ -505,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "patina_macro"
-version = "14.3.2"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf1a92cdc2283e31ba038871c6141f09c19b53620509257a21b22523a2491a80"
+checksum = "c21d92c8e60f349edb3ed875d75445447da2c71e124710bb94db8097dde5142e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -517,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "patina_mm"
-version = "14.3.2"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26340cde395095da3b769127a89e18ac8d88d4f26550e1bf3e2b40383adb491e"
+checksum = "b923af19fd8b2f837eb192614fc4ce0f291a26181067fb4782f528d4c57a427f"
 dependencies = [
  "cfg-if",
  "log",
@@ -532,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "patina_mtrr"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29117ee0cbc965c73f13761f0ebbcbefbaf500923f8e8af4d0d3926dd6be30b8"
+checksum = "b1798c2b80b7d43aecc6ca85cd18be519ca2b13444faa38314a4d530cbc93c05"
 dependencies = [
  "bitfield-struct",
  "cfg-if",
@@ -554,16 +566,16 @@ dependencies = [
 
 [[package]]
 name = "patina_performance"
-version = "14.3.2"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7773281daaa35bca1ece6324411cfa1148bcefd9ef243593d02d5d4b08dcd8a4"
+checksum = "95a1c416d2121fd273c0a5af283b971cb879b4f266b044d94258d816908166a6"
 dependencies = [
  "log",
  "mu_rust_helpers",
  "patina",
  "patina_internal_device_path",
+ "patina_mm",
  "r-efi",
- "scroll",
  "uuid",
  "zerocopy",
  "zerocopy-derive",
@@ -571,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "patina_samples"
-version = "14.3.2"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1e0bc2414099b63f4ef7b5b19cf69be48fd9d45bcba60cefc822a3fe0367b3"
+checksum = "e5b78eb28b802048aa4e0af76626597540c5615ec98ee2d284d41c46eebd0282"
 dependencies = [
  "log",
  "patina",
@@ -583,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "patina_smbios"
-version = "14.3.2"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421c4bba216fa1b548da1b1f3065be4a15ef491e3fecf5b43d58025f9c47f3a2"
+checksum = "28dffa99bc7f6d83a826aab4fb46160427d827d1fed282da0af7ec6997606387"
 dependencies = [
  "log",
  "patina",
@@ -598,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "patina_stacktrace"
-version = "14.3.2"
+version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc7367d91d160bf15a6714afdb77527d81ed3536c63893a0f46023772029cf7f"
+checksum = "0222ea605b91c942f86ac06738b91b4c9c038bc222b0df787cf8b5e379c263be"
 dependencies = [
  "cfg-if",
  "log",
@@ -629,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "qemu_dxe_core"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "log",
  "patina",
@@ -781,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.109"
+version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f17c7e013e88258aa9543dcbe81aca68a667a9ac37cd69c9fbc07858bfe0e2f"
+checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -852,6 +864,12 @@ name = "tock-registers"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b9e2fdb3a1e862c0661768b7ed25390811df1947a8acbfbefe09b47078d93c4"
+
+[[package]]
+name = "tock-registers"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d2d250f87fb3fb6f225c907cf54381509f47b40b74b1d1f12d2dccbc915bdfe"
 
 [[package]]
 name = "uart_16550"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qemu_dxe_core"
-version = "2.0.3"
+version = "2.0.4"
 edition = "2024"
 license = "Apache-2.0"
 
@@ -22,15 +22,15 @@ path = "src/lib.rs"
 log = { version = "^0.4", default-features = false, features = [
     "release_max_level_warn",
 ] }
-patina_adv_logger = { version = "14" }
-patina_debugger = { version = "14" }
-patina_dxe_core = { version = "14" }
-patina_mm = { version = "14" }
-patina_performance = { version = "14"}
-patina_samples = { version = "14" }
-patina = { version = "14", features = ["enable_patina_tests"] }
-patina_ffs_extractors = { version = "14" }
-patina_stacktrace = { version = "14" }
+patina_adv_logger = { version = "15" }
+patina_debugger = { version = "15" }
+patina_dxe_core = { version = "15" }
+patina_mm = { version = "15" }
+patina_performance = { version = "15"}
+patina_samples = { version = "15" }
+patina = { version = "15", features = ["enable_patina_tests"] }
+patina_ffs_extractors = { version = "15" }
+patina_stacktrace = { version = "15" }
 r-efi = { version = "^5", default-features = false }
 x86_64 = { version = "=0.15.2", default-features = false, features = [
   "instructions"

--- a/bin/q35_dxe_core.rs
+++ b/bin/q35_dxe_core.rs
@@ -42,6 +42,9 @@ static LOGGER: AdvancedLogger<Uart16550> = AdvancedLogger::new(
         ("gcd_measure", log::LevelFilter::Off),
         ("allocations", log::LevelFilter::Off),
         ("efi_memory_map", log::LevelFilter::Off),
+        ("mm_comm", log::LevelFilter::Off),
+        ("sw_mmi", log::LevelFilter::Off),
+        ("patina_performance", log::LevelFilter::Off),
     ],
     log::LevelFilter::Info,
     Uart16550::Io { base: 0x402 },
@@ -84,6 +87,8 @@ pub extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
             acpi_base: patina_mm::config::AcpiBase::Mmio(0x0), // Actual ACPI base address will be set during boot
             cmd_port: patina_mm::config::MmiPort::Smi(0xB2),
             data_port: patina_mm::config::MmiPort::Smi(0xB3),
+            enable_comm_buffer_updates: false,
+            updatable_buffer_id: None,
             comm_buffers: vec![],
         })
         .with_component(q35_services::mm_config_provider::MmConfigurationProvider)
@@ -95,8 +100,8 @@ pub extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
         //
         // Tracked in https://github.com/microsoft/mu_feature_mm_supv/issues/541
         //
-        // .with_component(patina_mm::component::communicator::MmCommunicator::new())
-        // .with_component(q35_services::mm_test::QemuQ35MmTest::new())
+        .with_component(patina_mm::component::communicator::MmCommunicator::new())
+        .with_component(q35_services::mm_test::QemuQ35MmTest::new())
         .with_config(patina_performance::config::PerfConfig {
             enable_component: true,
             enabled_measurements: {


### PR DESCRIPTION
## Description

Integrates the latest Patina release. The breaking changes in the `patina_mm` configuration interface are accounted for without changing behavior at this time. The comm buffer update capability will be used in the future when supporting changes are brought into patina-qemu for the change.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Build all platforms
- Test Q35 boot
- SBSA boot to EFI shell

## Integration Instructions

- N/A