### PR TITLE
Update to patina v17.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "aarch64-cpu"
-version = "11.1.0"
+version = "11.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2902b1d87157187000598c0dfc24f438b01792bc10d257c671bd65e24f4b5878"
+checksum = "44171e22925ec72b63d86747bc3655c7849a5b8d865c980222128839f45ac034"
 dependencies = [
  "tock-registers 0.10.1",
 ]
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
 dependencies = [
  "crc-catalog",
 ]
@@ -187,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "goblin"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51876e3748c4a347fe65b906f2b1ae46a1e55a497b22c94c1f4f2c469ff7673a"
+checksum = "4db6758c546e6f81f265638c980e5e84dfbda80cfd8e89e02f83454c8e8124bd"
 dependencies = [
  "log",
  "plain",
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "managed"
@@ -340,13 +340,14 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "patina"
-version = "16.0.1"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8aa220470b0ff81ace46ba3936f5f1a58fd513d9922a4e8778f7c27f503b40"
+checksum = "cdd8839e4880b908dfeec0f74f251245dc6504fde00c462de2a1e23be6e3ee30"
 dependencies = [
  "cfg-if",
  "fallible-streaming-iterator",
  "fixedbitset",
+ "goblin",
  "indoc",
  "linkme",
  "log",
@@ -365,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "patina_adv_logger"
-version = "16.0.1"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03e129e53e08350ab48edaf30f70268f89c5b41233dc7bf34d40ee6794ff59c"
+checksum = "3aba9657c47feac38588cf13367886358c6d0e2ec0c241ba3b15efc3318ba341"
 dependencies = [
  "log",
  "mu_rust_helpers",
@@ -380,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "patina_debugger"
-version = "16.0.1"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee30843b6ba89be8949b31aae53c45cf14c4fe40c3f285d2f552a63077cebebc"
+checksum = "67d0528506c8ac9aa912586547bdfd591b0ae3796b9f6039aa0d513c5b6a4958"
 dependencies = [
  "bitfield-struct",
  "cfg-if",
@@ -397,11 +398,11 @@ dependencies = [
 
 [[package]]
 name = "patina_dxe_core"
-version = "16.0.1"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb970bf2f4ae14e60866da0cd3834ab6841628745b5d4441431333691b5bd85"
+checksum = "bac7696b072f2e7af1a95bd94b0f7967c378373fe949053fe302a1e0e6dba248"
 dependencies = [
- "aarch64-cpu 11.1.0",
+ "aarch64-cpu 11.2.0",
  "arm-gic",
  "cfg-if",
  "compile-time",
@@ -429,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs"
-version = "16.0.1"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd68bf6a15b78d32878e55003408e1aee9f9f4be55d048f2a11580e35f2ff21"
+checksum = "ee3dce21d1b645b85f8e887800ff372c026b36cf29c00a02a0d9cf76617748b7"
 dependencies = [
  "log",
  "patina",
@@ -440,9 +441,9 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs_extractors"
-version = "16.0.1"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a166683852ace95c3e871f65445c9b9cab1f1d55868814db84d1362249b21793"
+checksum = "fd37c3a5bb2efb38f7bd6b5c4db1e8768ba4b1ddc60235564efba610d82eda94"
 dependencies = [
  "alloc-no-stdlib",
  "brotli-decompressor",
@@ -456,18 +457,18 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_collections"
-version = "16.0.1"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f13e1408bdca18230d9f9596ff1d8ab082fc4ec3eeeac0ffe041210981d69ef"
+checksum = "5a68d7e983be0e04a57537d58151b9543489362a370f5043aadf954fc9c94d5d"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "patina_internal_cpu"
-version = "16.0.1"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ed289589527a7197eff999936f88a86faa58a70d97e78c706c2de186a896f9"
+checksum = "47c031704919e8ee995b7a519d73277d2ce3b3aa28cf60f907c02985ce67c72e"
 dependencies = [
  "arm-gic",
  "cfg-if",
@@ -485,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_depex"
-version = "16.0.1"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2930fbfa34646ce69a17fcb70e0105baf9ae02fef2cd55f5e5e541223eb78aa3"
+checksum = "cf57aad7c01d9d7320363f47b1ce3b8fc34f745aaa1a368842c826fe3f827daa"
 dependencies = [
  "log",
  "r-efi",
@@ -496,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_device_path"
-version = "16.0.1"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93c5a9c5b9ccb5d34c7fadb786890d1f2f0a961d3c3d147e2a624d9204f609f"
+checksum = "eaa76ae9646ff4c249631f4d6b03c19cfca99b598f45af853109a733ac222c46"
 dependencies = [
  "log",
  "r-efi",
@@ -517,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "patina_macro"
-version = "16.0.1"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29728ac86a616e868d8d18667ed1ebd83c221185ba89c5148a1848b7364c3ef4"
+checksum = "1285de8961e820e5de95d46e6c3330c2da52fc880a55ed79c4ae05f659079bff"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -529,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "patina_mm"
-version = "16.0.1"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b8bd6836d9b0d2923eab0c552f0e5c1c4f57ff87844df44c582afc9a80b2a3"
+checksum = "3141ddbc806d024e62f266f69c39ff3f8083dd736404ecb9a3d879239bcd1181"
 dependencies = [
  "cfg-if",
  "log",
@@ -566,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "patina_performance"
-version = "16.0.1"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643740f4a0f3e393942f9f18f54913bd2d17238e48814d59b894dd72c78dcce1"
+checksum = "129fbfdcd9ad0c7f65af6cce8ac99563a12ff1d968186e746681c619e0818680"
 dependencies = [
  "log",
  "mu_rust_helpers",
@@ -583,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "patina_samples"
-version = "16.0.1"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e9df2eafa71f5ff032fb34cc22674f51fbda9317006f21f32766c5bbe0d5f5"
+checksum = "acfcda50d719014fd382d803eaf41be2592630413ec6884ca4425a5672db750f"
 dependencies = [
  "log",
  "patina",
@@ -595,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "patina_smbios"
-version = "16.0.1"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd5f6b446037a08621dfe40de0b2da36697ca09b9950d40ccebdd223d854d080"
+checksum = "db1b544f9a3d9e6609fd388dc1b4a5b76a8d691aa447b8a5fc8449e3467bea8f"
 dependencies = [
  "log",
  "patina",
@@ -610,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "patina_stacktrace"
-version = "16.0.1"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869907f5dbcb37e532fe74c6dfcb6c3390a5fada784b1e72ba0fb3c1f66cc2c3"
+checksum = "8be95a0bd438b8fd2bb71bb9d13c5c53255b522d5b4c752f6d7991e74d6fcf95"
 dependencies = [
  "cfg-if",
  "log",
@@ -641,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "qemu_dxe_core"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "log",
  "patina",
@@ -705,9 +706,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "safe-mmio"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db02a82ad13df46afeba34a4e54065fa912308b9101b060e4422898eac0e06f6"
+checksum = "1e278214ff688cacb43a8e71611d1fd1b0788a8b55a054dbce9a9b70b9a6a6f2"
 dependencies = [
  "zerocopy",
 ]
@@ -793,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -901,9 +902,9 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 
 [[package]]
 name = "volatile"
@@ -945,18 +946,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.28"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fa6694ed34d6e57407afbccdeecfa268c470a7d2a5b0cf49ce9fcc345afb90"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.28"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c640b22cd9817fae95be82f0d2f90b11f7605f6c319d16705c459b27ac2cbc26"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qemu_dxe_core"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2024"
 license = "Apache-2.0"
 
@@ -22,15 +22,15 @@ path = "src/lib.rs"
 log = { version = "^0.4", default-features = false, features = [
     "release_max_level_warn",
 ] }
-patina_adv_logger = { version = "16" }
-patina_debugger = { version = "16" }
-patina_dxe_core = { version = "16" }
-patina_mm = { version = "16" }
-patina_performance = { version = "16"}
-patina_samples = { version = "16" }
-patina = { version = "16", features = ["enable_patina_tests"] }
-patina_ffs_extractors = { version = "16" }
-patina_stacktrace = { version = "16" }
+patina_adv_logger = { version = "17" }
+patina_debugger = { version = "17" }
+patina_dxe_core = { version = "17" }
+patina_mm = { version = "17" }
+patina_performance = { version = "17"}
+patina_samples = { version = "17" }
+patina = { version = "17", features = ["enable_patina_tests"] }
+patina_ffs_extractors = { version = "17" }
+patina_stacktrace = { version = "17" }
 r-efi = { version = "^5", default-features = false }
 x86_64 = { version = "=0.15.2", default-features = false, features = [
   "instructions"

--- a/src/q35/component/service/mm_config_provider.rs
+++ b/src/q35/component/service/mm_config_provider.rs
@@ -10,7 +10,7 @@
 //!
 
 use patina::component::{
-    IntoComponent,
+    component,
     hob::{FromHob, Hob},
     params::ConfigMut,
 };
@@ -22,7 +22,6 @@ extern crate alloc;
 
 /// Responsible for providing MM configuration information to other components. All other MM related components
 /// should be abstracted from MM details by the configuration produced by this component.
-#[derive(IntoComponent)]
 pub struct MmConfigurationProvider;
 
 /// Represents a MM Communication Region.
@@ -42,6 +41,7 @@ pub struct MmCommRegionHob {
     pages: u64,
 }
 
+#[component]
 impl MmConfigurationProvider {
     /// Entry point for the MM Configuration Provider.
     ///

--- a/src/q35/component/service/mm_control.rs
+++ b/src/q35/component/service/mm_control.rs
@@ -13,7 +13,7 @@
 use patina_mm::{config::MmCommunicationConfiguration, service::platform_mm_control::PlatformMmControl};
 
 use crate::q35::registers as register;
-use patina::component::{IntoComponent, Storage, service::IntoService};
+use patina::component::{Storage, component, service::IntoService};
 
 use x86_64::instructions::port::Port;
 
@@ -21,12 +21,13 @@ use x86_64::instructions::port::Port;
 ///
 /// This component is responsible for initializing and controlling the MM environment on the QEMU Q35 platform. All
 /// QEMU Q35-specific logic for initializing the hardware environment for MM should be contained within this component.
-#[derive(IntoComponent, IntoService, Default)]
+#[derive(IntoService, Default)]
 #[service(dyn PlatformMmControl)]
 pub struct QemuQ35PlatformMmControl {
     inner_config: MmCommunicationConfiguration,
 }
 
+#[component]
 impl QemuQ35PlatformMmControl {
     /// Creates a new instance of the QEMU Q35 platform MM control component.
     ///

--- a/src/q35/component/service/mm_test.rs
+++ b/src/q35/component/service/mm_test.rs
@@ -10,7 +10,7 @@
 //! SPDX-License-Identifier: Apache-2.0
 //!
 
-use patina::component::{IntoComponent, service::Service};
+use patina::component::{component, service::Service};
 use patina_mm::service::MmCommunication;
 
 /// MM Supervisor Request Header
@@ -46,9 +46,10 @@ struct MmSupervisorVersionInfo {
 /// QEMU Q35 MM Test Component
 ///
 /// Responsible for testing the MM communication interface on the QEMU Q35 platform.
-#[derive(Default, IntoComponent)]
+#[derive(Default)]
 pub struct QemuQ35MmTest;
 
+#[component]
 impl QemuQ35MmTest {
     /// Creates a new instance of the QEMU Q35 MM Test component.
     pub fn new() -> Self {

--- a/src/q35/timer.rs
+++ b/src/q35/timer.rs
@@ -30,11 +30,13 @@ pub unsafe fn calibrate_tsc_frequency(pm_timer_port: u16) -> u64 {
     const MAX_WAIT_CYCLES: usize = 1_000_000;
 
     // Wait for a PM timer edge to avoid partial intervals.
-    let mut start_pm = read_pm_timer(pm_timer_port);
+    // Safety: The provided PM timer port must be valid per the function's safety contract.
+    let mut start_pm = unsafe { read_pm_timer(pm_timer_port) };
     let mut next_pm;
     let mut calibration_cycles_left = MAX_WAIT_CYCLES;
     loop {
-        next_pm = read_pm_timer(pm_timer_port);
+        // Safety: The provided PM timer port must be valid per the function's safety contract.
+        next_pm = unsafe { read_pm_timer(pm_timer_port) };
         if next_pm != start_pm {
             break;
         }
@@ -63,7 +65,8 @@ pub unsafe fn calibrate_tsc_frequency(pm_timer_port: u16) -> u64 {
     let mut end_pm;
     calibration_cycles_left = MAX_WAIT_CYCLES;
     loop {
-        end_pm = read_pm_timer(pm_timer_port);
+        // Safety: The provided PM timer port must be valid per the function's safety contract.
+        end_pm = unsafe { read_pm_timer(pm_timer_port) };
         let delta = end_pm.wrapping_sub(start_pm);
         if delta >= target_ticks {
             break;


### PR DESCRIPTION
## Description

Updates to the latest Patina release integrating breaking changes.

The patch version of patina-dxe-core has been incremented to 2.1.2 to reflect that no specific work is expected in QEMU platform integration for this release.

---

Note: Waiting on the v17.0.0 release (in https://github.com/OpenDevicePartnership/patina/pull/1150) to be completed so this PR can pick up the new crates. It has been tested locally against those changes. It will be moved out of draft after that release is made.

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- QEMU boot to EFI shell

## Integration Instructions

- N/A