### PR TITLE
v2.2.2: Release the SMBIOS component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "qemu_dxe_core"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "log",
  "patina",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qemu_dxe_core"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Description

Bump the version to make a release that includes the SMBIOS component changes made for QEMU Q35 in c0041f7.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`

## Integration Instructions

- N/A