### PR TITLE
.github: Update rust-tool-cache to the patina-devops main branch

### DIFF
--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: 🛠️ Download Rust Tools 🛠️
-        uses: OpenDevicePartnership/patina-devops/.github/actions/rust-tool-cache@v0.0.4
+        uses: OpenDevicePartnership/patina-devops/.github/actions/rust-tool-cache@main
 
       - name: Build Q35 Debug
         run: cargo make q35


### PR DESCRIPTION
## Description

This version is maintained locally in the workflow. This change updates the workflow to use the version in the patina-devops branch to prevent it from falling behind in the future.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- These patina-devops changes have been tested in other repos.

## Integration Instructions

- N/A