### PR TITLE
Workflow: Generate QEMU Patina DXE Core binary size report on PRs

### DIFF
--- a/.github/workflows/binary-size-report.yml
+++ b/.github/workflows/binary-size-report.yml
@@ -13,11 +13,7 @@ on:
 jobs:
   run:
     name: Binary Size Report
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-latest ]
-
+    runs-on: ubuntu-latest
     steps:
       - name: Generate Token
         id: app-token

--- a/bin/q35_dxe_core.rs
+++ b/bin/q35_dxe_core.rs
@@ -109,8 +109,8 @@ impl ComponentInfo for Q35 {
         add.component(patina_mm::component::sw_mmi_manager::SwMmiManager::new());
         add.component(patina_mm::component::communicator::MmCommunicator::new());
         add.component(q35_services::mm_test::QemuQ35MmTest::new());
-        // add.component(patina_performance::component::performance_config_provider::PerformanceConfigurationProvider);
-        // add.component(patina_performance::component::performance::Performance);
+        add.component(patina_performance::component::performance_config_provider::PerformanceConfigurationProvider);
+        add.component(patina_performance::component::performance::Performance);
         add.component(patina_smbios::component::SmbiosProvider::new(3, 9));
         add.component(q35_services::smbios_platform::Q35SmbiosPlatform::new());
         add.component(patina::test::TestRunner::default().with_callback(|test_name, err_msg| {


### PR DESCRIPTION
## Description

- This workflow runs as part of every PR, generates a binary size report, and posts it as a PR comment

```
| Architecture | Commit                                       | Δ Debug Size | Δ Release Size |
|--------------|----------------------------------------------|--------------|----------------|
| x86_64       | Base:users/vineelko/size_compare_0127        |     1.86 MB  |   904.00 KB    |
|              | PR:users/vineelko/size_compare_0127_pr_check |     1.77 MB  |   870.00 KB    |
|              |                                              | Δ -85.00 KB  | Δ -34.00 KB    |
|--------------|----------------------------------------------|--------------|----------------|
| aarch64      | Base:users/vineelko/size_compare_0127        |     1.56 MB  |   786.50 KB    |
|              | PR:users/vineelko/size_compare_0127_pr_check |     1.56 MB  |   786.50 KB    |
|              |                                              | Δ   0.00 B   | Δ   0.00 B     |
'---------------------------------------------------------------------------------------------'
```
Address https://github.com/OpenDevicePartnership/patina/issues/784

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

https://github.com/vineelko/patina-dxe-core-qemu/actions/runs/21461640120
<img width="1436" height="589" alt="image" src="https://github.com/user-attachments/assets/27391a73-eea1-4f14-997e-c63310426157" />

## Integration Instructions

NA