### PR TITLE
binary-size-report.yml: Split the binary size report workflow

### DIFF
--- a/.github/workflows/binary-size-comment.yml
+++ b/.github/workflows/binary-size-comment.yml
@@ -1,0 +1,60 @@
+# @file binary-size-comment.yml
+#
+# GitHub Actions workflow to post binary size report comments on PRs.
+#
+# This workflow runs access to secrets.
+# It waits for the binary-size-report.yml workflow to complete and posts the comment.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Binary Size Comment
+
+on:
+  workflow_run:
+    workflows: ["Binary Size Report"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    name: Post Binary Size Comment
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: 📥 Download Binary Size Report Data
+        uses: actions/download-artifact@v7
+        with:
+          name: binary-size-report-data
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: 📖 Read PR Metadata
+        id: pr-data
+        shell: bash
+        run: |
+          echo "pr_number=$(cat pr_number.txt)" >> $GITHUB_OUTPUT
+          echo "base_ref=$(cat base_ref.txt)" >> $GITHUB_OUTPUT
+          echo "head_ref=$(cat head_ref.txt)" >> $GITHUB_OUTPUT
+
+      - name: Generate Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.PATINA_AUTOMATION_APPLICATION_ID }}
+          private-key: ${{ secrets.PATINA_AUTOMATION_APPLICATION_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: 📊 Post Binary Size Report as PR Comment
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.pr-data.outputs.pr_number }}
+        shell: bash
+        run: |
+          COMMENT_BODY=$(cat binary_size_report.md)
+
+          gh pr comment "$PR_NUMBER" \
+            --repo ${{ github.repository }} \
+            --body "$COMMENT_BODY"

--- a/.github/workflows/binary-size-report.yml
+++ b/.github/workflows/binary-size-report.yml
@@ -2,6 +2,10 @@
 #
 # GitHub Actions workflow to compare QEMU Patina DXE Core binary sizes for PRs.
 #
+# This workflow runs in an untrusted PR context to build the code on a fork and upload
+# the size data as an artifact. When it is complete, a separate workflow (binary-size-comment.yml)
+# operates exclusively on the size data artifact and posts the comment.
+#
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -15,13 +19,6 @@ jobs:
     name: Binary Size Report
     runs-on: ubuntu-latest
     steps:
-      - name: Generate Token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.PATINA_AUTOMATION_APPLICATION_ID }}
-          private-key: ${{ secrets.PATINA_AUTOMATION_APPLICATION_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
 
       - name: ✅ Checkout Base Branch (${{ github.base_ref }}) ✅
         uses: actions/checkout@v6
@@ -136,13 +133,18 @@ jobs:
 
           cat "$REPORT_FILE" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: 📊 Post Binary Size Report as PR Comment
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: 📁 Save PR Metadata and Report
+        shell: bash
         run: |
-          REPORT_FILE="$GITHUB_WORKSPACE/binary_size_report.md"
-          COMMENT_BODY=$(cat "$REPORT_FILE")
+          mkdir -p pr-data
+          echo "${{ github.event.pull_request.number }}" > pr-data/pr_number.txt
+          echo "${{ github.base_ref }}" > pr-data/base_ref.txt
+          echo "${{ github.head_ref }}" > pr-data/head_ref.txt
+          cp "$GITHUB_WORKSPACE/binary_size_report.md" pr-data/
 
-          gh pr comment ${{ github.event.pull_request.number }} \
-            --body "$COMMENT_BODY"
-
+      - name: 📤 Upload PR Data and Report
+        uses: actions/upload-artifact@v6
+        with:
+          name: binary-size-report-data
+          path: pr-data/
+          retention-days: 1


### PR DESCRIPTION
## Description

Split the binary size report workflow into two separate workflows to safely handle pull requests from untrusted forks:

1. `binary-size-report.yml` - Runs in an "untrusted PR context"
   - Builds binaries from both base and PR branches
   - Generates binary size comparison report
   - Uploads report and PR metadata as artifacts

   - Changed:
     - Removed GitHub App token generation and secrets access
     - No longer posts comments directly

2. `binary-size-comment.yml` - Runs in a "trusted context"
   - Triggers via `workflow_run` after report workflow completes
   - Downloads artifacts uploaded by the untrusted workflow
   - Generates the Patina GitHub App token
   - Posts binary size report as PR comment
   - Note: Never executes untrusted code

The original workflow needed to access secrets and builds the code from `github.event.pull_request.head.sha` directly. This splits the safety boundary for secret access and code execution.

Reference: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Testing (with Patina app secret) is WIP on fork

## Integration Instructions

- N/A