### PR TITLE
v2.2.8: Update to patina v20.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "arm-gic"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc8a5b06c02f993e98b0b3eb95c3acefb6889cc33a630621fb3e6c564502c2b0"
+checksum = "c044ecf8760dd8ee5aa92c49cf7534942d289fb1f0247af92b5fbab8ab18a912"
 dependencies = [
  "bitflags 2.10.0",
  "safe-mmio",
@@ -184,9 +184,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "gdbstub"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72742d2b395902caf8a5d520d0dd3334ba6d1138938429200e58d5174e275f3f"
+checksum = "6bf845b08f7c2ef3b5ad19f80779d43ae20d278652b91bb80adda65baf2d8ed6"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
@@ -324,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-traits"
@@ -351,9 +351,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "patina"
-version = "19.0.5"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a09c3efbc258ab1482783cdf0eac1a745d532af0518d11e1f30d66f7fe7e6b3"
+checksum = "4215d712660d1bbcfa3f3b5e4cc9e567a416c13ac46aa0b97cc96d6644969d74"
 dependencies = [
  "cfg-if",
  "fallible-streaming-iterator",
@@ -377,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "patina_adv_logger"
-version = "19.0.5"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab51d1b68ebfa135a634e4a23ec06dd8be345bbd8e216249c4623ecaee6eac54"
+checksum = "3a7e740adbb7432695f0e9d257ebe0444e0e4103475c4a94b84934cbe3861355"
 dependencies = [
  "log",
  "mu_rust_helpers",
@@ -392,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "patina_debugger"
-version = "19.0.5"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa75797ef8157220a9dcf457327ec54766a66983e4c7a90eeeb990944d5f1a2"
+checksum = "603ea3c534d4aaed089009fbbe52e9b424f41bf67f715d07144b347bff2a2861"
 dependencies = [
  "bitfield-struct 0.10.1",
  "cfg-if",
@@ -409,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "patina_dxe_core"
-version = "19.0.5"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac16df3ce44f9f6985d431bfbbdae8b8240c07a45f937ba6cb9a04dfc77d25f"
+checksum = "76a18c1e26dc311dc72b8a1f3be80497a1ecda6489ad1ed7a1046b963210226c"
 dependencies = [
  "aarch64-cpu 11.2.0",
  "arm-gic",
@@ -442,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs"
-version = "19.0.5"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b35113fcdc3fb2e008e314268e380d244e44ec4d644a01dfdae50350e429ea5"
+checksum = "157022bc36ad77f85cb5d5bf06ef57a2d686b3f6269932a422d1112ec2ab2cc8"
 dependencies = [
  "log",
  "patina",
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs_extractors"
-version = "19.0.5"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5af07992f9823208a72436961a5472bd6ce276779d16a351da5484c376d846a"
+checksum = "0b73e48a70f993817791d079f899b8d439fd897433a1b1fa4745c207ec6a4549"
 dependencies = [
  "alloc-no-stdlib",
  "brotli-decompressor",
@@ -469,18 +469,18 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_collections"
-version = "19.0.5"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7349705645927fe51fc48ee66ae08cd3843e74f0b6d948b41871a40dcd124784"
+checksum = "ff5a3d830d4c06a102c4652869dff98ad0f553ecab58ac87954fb7928645709e"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "patina_internal_cpu"
-version = "19.0.5"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4bb9b3c9d88bc6fe57b30accb663b9a58cc10668b2533a071114c53c4958b4"
+checksum = "b267a7b2a3a42983fb2028cfa666881953f745b00f7cbd6c9a6cf998e3754ff8"
 dependencies = [
  "arm-gic",
  "cfg-if",
@@ -498,9 +498,9 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_depex"
-version = "19.0.5"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e594cddae27722454cd2b5fda7ea8ae4b6f524e09b3b85af37e7b8c69562737b"
+checksum = "c1b186e8ac11b4b34fbe15b96691bb36bcbcfb8b57d6efc3c534e82d99f8d95f"
 dependencies = [
  "log",
  "r-efi",
@@ -509,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_device_path"
-version = "19.0.5"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f0f469cd594b2d5f546fd72b8d271384a352da98aa0970938b7d4bf9045c6ac"
+checksum = "6838d213ea2d87edb68686b36e29391e4b04a8d5b333b9af42034b6e6425572a"
 dependencies = [
  "log",
  "r-efi",
@@ -530,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "patina_macro"
-version = "19.0.5"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29360a47d103f6e9d0297ccaf1d0246addf4d6643e07b59d36494d55da2db853"
+checksum = "f7810cefdbcff355be70c06b559161a847fb62828879becccea2bfba02f15faa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -542,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "patina_mm"
-version = "19.0.5"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ad8af5e230d5e66400fa8b1cd5a30f86ead389ffe4fbe712bf69bc953a6c5b2"
+checksum = "f89276ec20a9bde759d629716e960ca338f3dae877a11cbf197c9f2881041c9f"
 dependencies = [
  "cfg-if",
  "log",
@@ -579,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "patina_performance"
-version = "19.0.5"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d398c4715e9641eb241d8498dd73d9b8153b5beee0e79d3dd08dd47f4c61a6"
+checksum = "5732b9cab7e3489ccf2683f844d1dad7229c533cd63a5ef9f1433488fbf4018e"
 dependencies = [
  "log",
  "mu_rust_helpers",
@@ -596,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "patina_samples"
-version = "19.0.5"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f9bc7710221a8d13eb36c7def4be628d156d1e3739b2bba04ab4de66b6f2914"
+checksum = "434abf7046821e9bcd0b410572c384b426587d9e377ade1e2424a183f2a71beb"
 dependencies = [
  "log",
  "patina",
@@ -608,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "patina_smbios"
-version = "19.0.5"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1307c6e5149971a501dd06bc7172817be6e7e9e0ef8271b5b3f073e677920c38"
+checksum = "88187bcb667ea2eff49b74ca79715591219b9e13aa1e93baeaa429efcd476a7c"
 dependencies = [
  "log",
  "patina",
@@ -623,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "patina_stacktrace"
-version = "19.0.5"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c88ff0cb66b08cb02e233007596834732b4f15ffa5fda90a343be55797e071bb"
+checksum = "4d808a84dc9010eff0d657405898b5e398d4fda6ed5b1fbb020d06836822eb10"
 dependencies = [
  "cfg-if",
  "log",
@@ -645,9 +645,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -660,7 +660,7 @@ checksum = "8bb0fd6580eeed0103c054e3fba2c2618ff476943762f28a645b63b8692b21c9"
 
 [[package]]
 name = "qemu_dxe_core"
-version = "2.2.7"
+version = "2.2.8"
 dependencies = [
  "log",
  "patina",
@@ -681,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -842,9 +842,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -857,15 +857,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -913,9 +913,9 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 
 [[package]]
 name = "volatile"
@@ -957,18 +957,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.38"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cf3aa6855b23711ee9852dfc97dfaa51c45feaba5b645d0c777414d494a961"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.38"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a616990af1a287837c4fe6596ad77ef57948f787e46ce28e166facc0cc1cb75"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qemu_dxe_core"
-version = "2.2.7"
+version = "2.2.8"
 edition = "2024"
 license = "Apache-2.0"
 
@@ -22,16 +22,16 @@ path = "src/lib.rs"
 log = { version = "^0.4", default-features = false, features = [
     "release_max_level_warn",
 ] }
-patina_adv_logger = { version = "19" }
-patina_debugger = { version = "19" }
-patina_dxe_core = { version = "19" }
-patina_mm = { version = "19" }
-patina_performance = { version = "19"}
-patina_samples = { version = "19" }
-patina_smbios = { version = "19"}
-patina = { version = "19", features = ["enable_patina_tests"] }
-patina_ffs_extractors = { version = "19" }
-patina_stacktrace = { version = "19" }
+patina_adv_logger = { version = "20" }
+patina_debugger = { version = "20" }
+patina_dxe_core = { version = "20" }
+patina_mm = { version = "20" }
+patina_performance = { version = "20"}
+patina_samples = { version = "20" }
+patina_smbios = { version = "20"}
+patina = { version = "20", features = ["enable_patina_tests"] }
+patina_ffs_extractors = { version = "20" }
+patina_stacktrace = { version = "20" }
 r-efi = { version = "^5", default-features = false }
 x86_64 = { version = "=0.15.2", default-features = false, features = [
   "instructions"


### PR DESCRIPTION
## Description

Updates to patina v20.0.0. Release notes:

https://github.com/OpenDevicePartnership/patina/releases/tag/patina-v20.0.0

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Q35 EFI shell boot
- SBSA EFI shell boot

## Integration Instructions

- N/A