### PR TITLE
v2.2.9: Update to Patina 20.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,9 +351,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "patina"
-version = "20.0.0"
+version = "20.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4215d712660d1bbcfa3f3b5e4cc9e567a416c13ac46aa0b97cc96d6644969d74"
+checksum = "b569ed913e1a28274d5de5b6d28e9cdfcfbe7566b89cfbf0779b24dd5286d511"
 dependencies = [
  "cfg-if",
  "fallible-streaming-iterator",
@@ -377,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "patina_adv_logger"
-version = "20.0.0"
+version = "20.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a7e740adbb7432695f0e9d257ebe0444e0e4103475c4a94b84934cbe3861355"
+checksum = "1ea4dc22b726b324de4697507f7a1e34f8fffa6c8225e37ac4b51fc43dee5a66"
 dependencies = [
  "log",
  "mu_rust_helpers",
@@ -392,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "patina_debugger"
-version = "20.0.0"
+version = "20.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "603ea3c534d4aaed089009fbbe52e9b424f41bf67f715d07144b347bff2a2861"
+checksum = "687b30868355f19afa185eafa5ce42dfa6ac00906e23f5926cf5fbfd302704b0"
 dependencies = [
  "bitfield-struct 0.10.1",
  "cfg-if",
@@ -409,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "patina_dxe_core"
-version = "20.0.0"
+version = "20.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a18c1e26dc311dc72b8a1f3be80497a1ecda6489ad1ed7a1046b963210226c"
+checksum = "22c4421d7cd9b4e54d1113dbd27722b72cf4e39add6293098b00a4dd6c860a3f"
 dependencies = [
  "aarch64-cpu 11.2.0",
  "arm-gic",
@@ -442,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs"
-version = "20.0.0"
+version = "20.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157022bc36ad77f85cb5d5bf06ef57a2d686b3f6269932a422d1112ec2ab2cc8"
+checksum = "65d8da00d1998a20926302775e1764ccdab3e4ba4125fd7a9a91b0d6585304d7"
 dependencies = [
  "log",
  "patina",
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs_extractors"
-version = "20.0.0"
+version = "20.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b73e48a70f993817791d079f899b8d439fd897433a1b1fa4745c207ec6a4549"
+checksum = "0f0ad5caf11defa8f9fa8b2b42c98122c6d6f11fa6d4518ff667e6e0fccd52a0"
 dependencies = [
  "alloc-no-stdlib",
  "brotli-decompressor",
@@ -469,18 +469,18 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_collections"
-version = "20.0.0"
+version = "20.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff5a3d830d4c06a102c4652869dff98ad0f553ecab58ac87954fb7928645709e"
+checksum = "758b44cb47c182397a40c2e328c10daa0fc66ec2b1c26fdbbc7555846efd29d4"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "patina_internal_cpu"
-version = "20.0.0"
+version = "20.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b267a7b2a3a42983fb2028cfa666881953f745b00f7cbd6c9a6cf998e3754ff8"
+checksum = "3eb172e27b3913a76ebd6005850a6109204e3294ddf66af3a3b890430516a2ab"
 dependencies = [
  "arm-gic",
  "cfg-if",
@@ -498,9 +498,9 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_depex"
-version = "20.0.0"
+version = "20.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b186e8ac11b4b34fbe15b96691bb36bcbcfb8b57d6efc3c534e82d99f8d95f"
+checksum = "b9c36e247c69a8957da9ae533c55bdd8127a46fa881d38a9bc41a37ea65dfe1f"
 dependencies = [
  "log",
  "r-efi",
@@ -509,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_device_path"
-version = "20.0.0"
+version = "20.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6838d213ea2d87edb68686b36e29391e4b04a8d5b333b9af42034b6e6425572a"
+checksum = "c691b6803a967f601843cfe02b559692dce7de0445a958ad832f1c605015bc69"
 dependencies = [
  "log",
  "r-efi",
@@ -530,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "patina_macro"
-version = "20.0.0"
+version = "20.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7810cefdbcff355be70c06b559161a847fb62828879becccea2bfba02f15faa"
+checksum = "aadc676e9b4f29373addbeab1e2eca4593dea2019a20ee96a54493700c12547a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -542,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "patina_mm"
-version = "20.0.0"
+version = "20.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89276ec20a9bde759d629716e960ca338f3dae877a11cbf197c9f2881041c9f"
+checksum = "fc2bc08340fc2b31dfcdf682ca233c251e883c74d6ed4d8c53d531ba8ce10d2e"
 dependencies = [
  "cfg-if",
  "log",
@@ -579,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "patina_performance"
-version = "20.0.0"
+version = "20.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5732b9cab7e3489ccf2683f844d1dad7229c533cd63a5ef9f1433488fbf4018e"
+checksum = "c8835459beddcd6b1f20032f3f007accb60fbfae3bc0537ce8727c87ca14822b"
 dependencies = [
  "log",
  "mu_rust_helpers",
@@ -596,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "patina_samples"
-version = "20.0.0"
+version = "20.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434abf7046821e9bcd0b410572c384b426587d9e377ade1e2424a183f2a71beb"
+checksum = "67ef5bc031389b91b86f1f70fa34a5f3c4226584fc3f20af68ba4a492d741ecf"
 dependencies = [
  "log",
  "patina",
@@ -608,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "patina_smbios"
-version = "20.0.0"
+version = "20.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88187bcb667ea2eff49b74ca79715591219b9e13aa1e93baeaa429efcd476a7c"
+checksum = "bafe86b4c019a4a728244892c598f3622e67e0d9ce1de0f41e3d11fcbbcd05de"
 dependencies = [
  "log",
  "patina",
@@ -623,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "patina_stacktrace"
-version = "20.0.0"
+version = "20.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d808a84dc9010eff0d657405898b5e398d4fda6ed5b1fbb020d06836822eb10"
+checksum = "2596ebc784281ce569348ed06290bdfd6535285d1f7e0908d2e2ecd5afab9f3f"
 dependencies = [
  "cfg-if",
  "log",
@@ -907,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qemu_dxe_core"
-version = "2.2.8"
+version = "2.2.9"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Description

Patina 20.0.1 contains, amongst other things, a bugfix for an incorrect create stack guard page. Pull this into patina-dxe-core-qemu so we can pull this fix into patina-qemu and re-enable the memory protection tests.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booting Q35 and SBSA and running the memory protection tests.

## Integration Instructions

N/A.