### PR TITLE
Change to release_max_level_info for log crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
 dependencies = [
  "powerfmt",
 ]
@@ -660,7 +660,7 @@ checksum = "8bb0fd6580eeed0103c054e3fba2c2618ff476943762f28a645b63b8692b21c9"
 
 [[package]]
 name = "qemu_dxe_core"
-version = "2.2.8"
+version = "2.2.10"
 dependencies = [
  "log",
  "patina",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qemu_dxe_core"
-version = "2.2.9"
+version = "2.2.10"
 edition = "2024"
 license = "Apache-2.0"
 
@@ -20,7 +20,7 @@ path = "src/lib.rs"
 
 [dependencies]
 log = { version = "^0.4", default-features = false, features = [
-    "release_max_level_warn",
+    "release_max_level_info",
 ] }
 patina_adv_logger = { version = "20" }
 patina_debugger = { version = "20" }


### PR DESCRIPTION
## Description

Adv logger tests have been failng for release builds in patina-qemu because the memory log is not getting populated. This is due to the release_max_level_warn feature in the log crate.

This commit changes it to release_max_level_info, which matches the recommendation from platforms: log fully to the memory log and control HW port log level differently in release builds.

The HW port log level is already configured correctly for release builds in patina-dxe-core-qemu.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on Q35 running the adv logger tests.

## Integration Instructions

N/A.
