### PR TITLE
Add OVMF Patina DXE Core binary

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,19 +6,3 @@
 
 [net]
 git-fetch-with-cli = true
-
-[target.x86_64-unknown-uefi]
-rustflags = [
-    "-C", "link-arg=/base:0x0",
-    "-C", "link-arg=/subsystem:efi_boot_service_driver",
-    "-C", "force-unwind-tables", # Generates .pdata section for stack tracing
-    "-C", "link-arg=/PDBALTPATH:qemu_q35_dxe_core.pdb",
-]
-
-[target.aarch64-unknown-uefi]
-rustflags = [
-    "-C", "link-arg=/base:0x0",
-    "-C", "link-arg=/subsystem:efi_boot_service_driver",
-    "-C", "force-unwind-tables", # Generates .pdata section for stack tracing
-    "-C", "link-arg=/PDBALTPATH:qemu_sbsa_dxe_core.pdb",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,11 @@ name = "qemu_sbsa_dxe_core"
 path = "bin/sbsa_dxe_core.rs"
 required-features = ["aarch64"]
 
+[[bin]]
+name = "qemu_ovmf_dxe_core"
+path = "bin/ovmf_dxe_core.rs"
+required-features = ["x64"]
+
 [lib]
 name = "qemu_resources"
 path = "src/lib.rs"
@@ -58,6 +63,7 @@ opt-level = 0
 [features]
 default = ["compatibility_mode_allowed"]
 compatibility_mode_allowed = ["patina_dxe_core/compatibility_mode_allowed"]
+v1_resource_descriptor_support = ["patina_dxe_core/v1_resource_descriptor_support"]
 x64 = ["x86_64"]
 aarch64 = []
 doc = []

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -13,6 +13,8 @@ STD_FLAGS = "--profile ${RUSTC_PROFILE} --features std"
 TEST_FLAGS = { value = "", condition = { env_not_set = ["TEST_FLAGS"] } }
 COV_FLAGS = { value = "--workspace --profile test --ignore-filename-regex .*test.*", condition = { env_not_set = ["COV_FLAGS"] } }
 RUSTDOCFLAGS = "-D warnings -D missing_docs"
+# Common rustflags used in all targets
+COMMON_RUSTFLAGS = "-C link-arg=/base:0x0 -C link-arg=/subsystem:efi_boot_service_driver -C force-unwind-tables"
 
 [env.development]
 RUSTC_PROFILE = "dev"
@@ -338,22 +340,32 @@ run_task = "build-efi-exec"
 
 [tasks.q35]
 description = """Builds the DEBUG Q35 UEFI firmware."""
-env = { CARGO_BIN_NAME = "qemu_q35_dxe_core", "RUSTC_PROFILE" = "dev", CARGO_BIN_TARGET = "x86_64-unknown-uefi", CARGO_BIN_FEATURES = "x64,build_debugger" }
+env = { CARGO_BIN_NAME = "qemu_q35_dxe_core", "RUSTC_PROFILE" = "dev", CARGO_BIN_TARGET = "x86_64-unknown-uefi", CARGO_BIN_FEATURES = "x64,build_debugger", CARGO_TARGET_X86_64_UNKNOWN_UEFI_RUSTFLAGS = "${COMMON_RUSTFLAGS} -C link-arg=/PDBALTPATH:qemu_q35_dxe_core.pdb" }
 run_task = "patch"
 
 [tasks.q35-release]
 description = """Builds the RELEASE Q35 UEFI firmware."""
-env = { CARGO_BIN_NAME = "qemu_q35_dxe_core", "RUSTC_PROFILE" = "release", CARGO_BIN_TARGET = "x86_64-unknown-uefi", CARGO_BIN_FEATURES = "x64" }
+env = { CARGO_BIN_NAME = "qemu_q35_dxe_core", "RUSTC_PROFILE" = "release", CARGO_BIN_TARGET = "x86_64-unknown-uefi", CARGO_BIN_FEATURES = "x64", CARGO_TARGET_X86_64_UNKNOWN_UEFI_RUSTFLAGS = "${COMMON_RUSTFLAGS} -C link-arg=/PDBALTPATH:qemu_q35_dxe_core.pdb" }
 run_task = "patch"
 
 [tasks.sbsa]
 description = """Builds the DEBUG SBSA UEFI firmware."""
-env = { CARGO_BIN_NAME = "qemu_sbsa_dxe_core", "RUSTC_PROFILE" = "dev", CARGO_BIN_TARGET = "aarch64-unknown-uefi", CARGO_BIN_FEATURES = "aarch64,build_debugger" }
+env = { CARGO_BIN_NAME = "qemu_sbsa_dxe_core", "RUSTC_PROFILE" = "dev", CARGO_BIN_TARGET = "aarch64-unknown-uefi", CARGO_BIN_FEATURES = "aarch64,build_debugger", CARGO_TARGET_AARCH64_UNKNOWN_UEFI_RUSTFLAGS = "${COMMON_RUSTFLAGS} -C link-arg=/PDBALTPATH:qemu_sbsa_dxe_core.pdb" }
 run_task = "patch"
 
 [tasks.sbsa-release]
 description = """Builds the RELEASE SBSA UEFI firmware."""
-env = { CARGO_BIN_NAME = "qemu_sbsa_dxe_core", "RUSTC_PROFILE" = "release", CARGO_BIN_TARGET = "aarch64-unknown-uefi", CARGO_BIN_FEATURES = "aarch64" }
+env = { CARGO_BIN_NAME = "qemu_sbsa_dxe_core", "RUSTC_PROFILE" = "release", CARGO_BIN_TARGET = "aarch64-unknown-uefi", CARGO_BIN_FEATURES = "aarch64", CARGO_TARGET_AARCH64_UNKNOWN_UEFI_RUSTFLAGS = "${COMMON_RUSTFLAGS} -C link-arg=/PDBALTPATH:qemu_sbsa_dxe_core.pdb" }
+run_task = "patch"
+
+[tasks.ovmf]
+description = """Builds the DEBUG OVMF UEFI firmware."""
+env = { CARGO_BIN_NAME = "qemu_ovmf_dxe_core", "RUSTC_PROFILE" = "dev", CARGO_BIN_TARGET = "x86_64-unknown-uefi", CARGO_BIN_FEATURES = "x64,build_debugger,v1_resource_descriptor_support", CARGO_TARGET_X86_64_UNKNOWN_UEFI_RUSTFLAGS = "${COMMON_RUSTFLAGS} -C link-arg=/PDBALTPATH:qemu_ovmf_dxe_core.pdb" }
+run_task = "patch"
+
+[tasks.ovmf-release]
+description = """Builds the RELEASE OVMF UEFI firmware."""
+env = { CARGO_BIN_NAME = "qemu_ovmf_dxe_core", "RUSTC_PROFILE" = "release", CARGO_BIN_TARGET = "x86_64-unknown-uefi", CARGO_BIN_FEATURES = "x64,v1_resource_descriptor_support", CARGO_TARGET_X86_64_UNKNOWN_UEFI_RUSTFLAGS = "${COMMON_RUSTFLAGS} -C link-arg=/PDBALTPATH:qemu_ovmf_dxe_core.pdb" }
 run_task = "patch"
 
 [tasks.doc]
@@ -450,8 +462,10 @@ dependencies = [
     "clippy",
     "cspell",
     "q35",
+    "ovmf",
     "sbsa",
     "q35-release",
+    "ovmf-release",
     "sbsa-release",
     "test",
     "coverage",

--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ binary in the [patina-qemu](https://github.com/OpenDevicePartnership/patina-qemu
    Output File:      'target/x86_64-unknown-uefi/release/qemu_q35_dxe_core.efi'
    ```
 
+- OVMF (x64) debug
+
+   ```shell
+   Compile Command:  'cargo make ovmf'
+   Output File:      'target/x86_64-unknown-uefi/debug/qemu_ovmf_dxe_core.efi'
+   ```
+
+- OVMF (x64) release
+
+   ```shell
+   Compile Command:  'cargo make ovmf-release'
+   Output File:      'target/x86_64-unknown-uefi/release/qemu_ovmf_dxe_core.efi'
+   ```
+
 - SBSA (aarch64) debug
 
    ```shell

--- a/bin/ovmf_dxe_core.rs
+++ b/bin/ovmf_dxe_core.rs
@@ -1,0 +1,101 @@
+//! DXE Core Sample X64 Binary for the Open Virtual Machine Firmware (OVMF) platform.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+#![cfg(all(target_os = "uefi", feature = "x64"))]
+#![no_std]
+#![no_main]
+
+use core::{ffi::c_void, panic::PanicInfo};
+use patina::{
+    log::{Format, SerialLogger},
+    serial::uart::Uart16550,
+};
+use patina_dxe_core::*;
+use patina_ffs_extractors::CompositeSectionExtractor;
+use patina_stacktrace::StackTrace;
+use qemu_resources::q35::timer;
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    log::error!("{}", info);
+
+    if let Err(err) = unsafe { StackTrace::dump() } {
+        log::error!("StackTrace: {}", err);
+    }
+
+    if patina_debugger::enabled() {
+        patina_debugger::breakpoint();
+    }
+
+    loop {}
+}
+
+static LOGGER: SerialLogger<Uart16550> = SerialLogger::new(
+    Format::Standard,
+    &[
+        ("allocations", log::LevelFilter::Off),
+        ("efi_memory_map", log::LevelFilter::Off),
+        ("gcd_measure", log::LevelFilter::Off),
+        ("goblin", log::LevelFilter::Off),
+    ],
+    log::LevelFilter::Info,
+    Uart16550::Io { base: 0x402 },
+);
+
+const PM_TIMER_PORT: u16 = 0x608;
+const _ENABLE_DEBUGGER: bool = cfg!(feature = "enable_debugger");
+
+#[cfg(feature = "build_debugger")]
+static DEBUGGER: patina_debugger::PatinaDebugger<Uart16550> =
+    patina_debugger::PatinaDebugger::new(Uart16550::Io { base: 0x3F8 })
+        .with_force_enable(_ENABLE_DEBUGGER)
+        .with_log_policy(patina_debugger::DebuggerLoggingPolicy::FullLogging);
+
+struct OVMF;
+
+// Default `MemoryInfo` implementation is sufficient for OVMF.
+impl MemoryInfo for OVMF {}
+
+// OVMF should use TSC frequency calibrated from ACPI PM Timer.
+impl CpuInfo for OVMF {
+    fn perf_timer_frequency() -> Option<u64> {
+        // SAFETY: Reading from the PM Timer I/O port is safe as long as the port is valid.
+        // On OVMF, the PM Timer is always available at the specified port address.
+        Some(unsafe { timer::calibrate_tsc_frequency(PM_TIMER_PORT) })
+    }
+}
+
+impl ComponentInfo for OVMF {
+    fn configs(_add: Add<Config>) {
+        // Add components and configs later
+    }
+
+    fn components(_add: Add<Component>) {
+        // Add components and configs later
+    }
+}
+
+impl PlatformInfo for OVMF {
+    type CpuInfo = Self;
+    type MemoryInfo = Self;
+    type ComponentInfo = Self;
+    type Extractor = CompositeSectionExtractor;
+}
+
+static CORE: Core<OVMF> = Core::new(CompositeSectionExtractor::new());
+
+#[cfg_attr(target_os = "uefi", unsafe(export_name = "efi_main"))]
+pub extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
+    log::set_logger(&LOGGER).map(|()| log::set_max_level(log::LevelFilter::Trace)).unwrap();
+
+    #[cfg(feature = "build_debugger")]
+    patina_debugger::set_debugger(&DEBUGGER);
+
+    log::info!("DXE Core Platform Binary v{}", env!("CARGO_PKG_VERSION"));
+    CORE.entry_point(physical_hob_list)
+}

--- a/cspell.yml
+++ b/cspell.yml
@@ -36,6 +36,7 @@ words:
   - mmio
   - mmram
   - msuefi
+  - ovmf
   - pdata
   - pdbaltpath
   - pemfile


### PR DESCRIPTION
## Description

Adds the `qemu_ovmf_dxe_core` binary for the OVMF (x64) platform.

- Adds bin/ovmf_dxe_core.rs to contain OVMF-specific configuration
- Moves rustflags from .cargo/config.toml to Makefile.toml so they can be set per binary target (not just target triple)
- Adds v1_resource_descriptor_support feature to Cargo.toml so it can be enabled per target when needed (for OVMF binary)
- Adds ovmf and ovmf-release build tasks to Makefile.toml

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- `cargo make ovmf`
- `cargo make ovmf-release`
- `cargo make all`
- Boot OVMF using the following edk2 branch - [makubacki/patina_ovmfpkg](https://github.com/makubacki/edk2/tree/patina_ovmfpkg)
  ```bash
  > stuart_build -c .\OvmfPkg\PlatformCI\PlatformBuild.py Target=DEBUG -a X64 TOOL_CHAIN_TAG=VS2022 BLD_*_PATINA_ENABLED=TRUE BLD_*_DXE_CORE_PATH=C:\src\patina-dxe-core-qemu\target\x86_64-unknown-uefi --FlashRom
  ```

## Integration Instructions

- This makes a Patina DXE Core binary available to those interested in using Patina with the OVMF platform. The commits in the [makubacki/patina_ovmfpkg](https://github.com/makubacki/edk2/tree/patina_ovmfpkg) branch must be used.