### PR TITLE
bin: Drop debug conditional breakpoint

### DIFF
--- a/bin/ovmf_dxe_core.rs
+++ b/bin/ovmf_dxe_core.rs
@@ -28,9 +28,7 @@ fn panic(info: &PanicInfo) -> ! {
         log::error!("StackTrace: {}", err);
     }
 
-    if patina_debugger::enabled() {
-        patina_debugger::breakpoint();
-    }
+    patina_debugger::breakpoint();
 
     loop {}
 }

--- a/bin/q35_dxe_core.rs
+++ b/bin/q35_dxe_core.rs
@@ -30,9 +30,7 @@ fn panic(info: &PanicInfo) -> ! {
         log::error!("StackTrace: {}", err);
     }
 
-    if patina_debugger::enabled() {
-        patina_debugger::breakpoint();
-    }
+    patina_debugger::breakpoint();
 
     loop {}
 }

--- a/bin/sbsa_dxe_core.rs
+++ b/bin/sbsa_dxe_core.rs
@@ -26,9 +26,7 @@ fn panic(info: &PanicInfo) -> ! {
         log::error!("StackTrace: {}", err);
     }
 
-    if patina_debugger::enabled() {
-        patina_debugger::breakpoint();
-    }
+    patina_debugger::breakpoint();
 
     loop {}
 }


### PR DESCRIPTION
## Description

Commit https://github.com/OpenDevicePartnership/patina/commit/1b7a6faa9cc55080bcd4f974bfffb4fab755d98c checks whether the debugger is enabled in `breakpoint()` so remove the redundant check in these bin files.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
- The original change was already tested with the debugger enabled

## Integration Instructions

- N/A