### PR TITLE
Add SMBIOS processor, cache, and memory types for SBSA

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -23,6 +23,7 @@ words:
   - acpi
   - apmc
   - depex
+  - dimm
   - dxecore
   - fadt
   - edk2
@@ -40,6 +41,7 @@ words:
   - pdata
   - pdbaltpath
   - pemfile
+  - pmic
   - pmbase
   - pmcon
   - pytool


### PR DESCRIPTION
## Description

Add SMBIOS Types 4, 7, 16, 17, 19 to the SBSA platform component and add "dimm"/"pmic" to cspell.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all` passes
- Ran `smbiosview` in UEFI Shell on QEMU SBSA and compared records
- Verified records from OS side with ARM WinVOS image on QEMU SBSA

## Integration Instructions

Requires patina-qemu branch `smbios-sbsa-integration` which removes TianoCore SmbiosDxe drivers and updates SbsaQemuSmbiosDxe to use `SMBIOS_HANDLE_PI_RESERVED`.