### PR TITLE
Update version to 2.2.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ checksum = "8bb0fd6580eeed0103c054e3fba2c2618ff476943762f28a645b63b8692b21c9"
 
 [[package]]
 name = "qemu_dxe_core"
-version = "2.2.11"
+version = "2.2.12"
 dependencies = [
  "log",
  "patina",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qemu_dxe_core"
-version = "2.2.11"
+version = "2.2.12"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Description

Includes:

- Update to patina v20.0.3
- SMBIOS processor, cache, and memory types for SBSA

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- N/A: Release of existing content

## Integration Instructions

- See patina-dxe-core-qemu v2.2.12 GitHub release notes