### PR TITLE
Update version to 2.2.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "corosensei"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c54787b605c7df106ceccf798df23da4f2e09918defad66705d1cedf3bb914f"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "scopeguard",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,9 +362,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "patina"
-version = "20.0.3"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e020ae8edf2946687199058930d264e823f27156abf55da2e43ad75647780b2"
+checksum = "8b22e6f05f2806a6705f481d120587b1d99be044c1fbbef6108f1d18b7a46c09"
 dependencies = [
  "cfg-if",
  "fallible-streaming-iterator",
@@ -377,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "patina_adv_logger"
-version = "20.0.3"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "814b5f1a817d8000ff3c6a5eaa5f21a5aba377d0df184c73c157849f8aaac1bb"
+checksum = "3c9cadc4de72cd9303bebd6ff6b145df424e22ed0197be4d4a9b4888790ea8b6"
 dependencies = [
  "log",
  "mu_rust_helpers",
@@ -392,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "patina_debugger"
-version = "20.0.3"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9fd61218cb3e45ddfc95a6cdd8bd5e9d56f9d14fcdabeab4e8796bd5da97ab7"
+checksum = "a9d69f4c46ce2d55d450557928b143ed8b765809a94e7c9d783b6647204be2f1"
 dependencies = [
  "bitfield-struct 0.12.1",
  "cfg-if",
@@ -409,15 +420,16 @@ dependencies = [
 
 [[package]]
 name = "patina_dxe_core"
-version = "20.0.3"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626b66f77c8c3760d3c7b4aff72432eb0135e12ab0356e6f50aa9be09ba7bc69"
+checksum = "481091f66440cdb92c9bd6e527a9b1471c301dfe96ebf06de504ccf783c2bd43"
 dependencies = [
  "aarch64-cpu 11.2.0",
  "arm-gic",
  "bitfield-struct 0.12.1",
  "cfg-if",
  "compile-time",
+ "corosensei",
  "crc32fast",
  "goblin",
  "lazy_static",
@@ -435,15 +447,14 @@ dependencies = [
  "r-efi",
  "scroll",
  "spin",
- "uefi_corosensei",
  "uuid",
 ]
 
 [[package]]
 name = "patina_ffs"
-version = "20.0.3"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b351bcad006287fb9f1a5ffa952265c4db344b5b1f5db3f7c6ab2fb65a60b44"
+checksum = "1c31f7f08d3d33d17ad54f7980da6f0805a3c395ca6ed6ca9d88ed73e161ebed"
 dependencies = [
  "log",
  "patina",
@@ -452,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs_extractors"
-version = "20.0.3"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf5591b9ac6ceee3c5be3006e3a2bc9e871b7a9b08f7a57287ae948ad79c22f5"
+checksum = "2b99b87ba6c7c9bfdd1091e1489cf07ae05d6e471807d6d5c75b042aa4a0f269"
 dependencies = [
  "alloc-no-stdlib",
  "brotli-decompressor",
@@ -468,18 +479,18 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_collections"
-version = "20.0.3"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a46987ad70ee77767900533216bc99efa29ec1acb9dfed4cf4b40207b7e8de75"
+checksum = "dcd6d5edd9ded0a2159a6e1a311fef9f4ec50186ddcda15e276f0e6cb992d12a"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "patina_internal_cpu"
-version = "20.0.3"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62dfe00a37fa0723d475f8f4e76f8a557576b752fa363c207bd0895786dfbbbb"
+checksum = "cd507f2b974a6c87942943d71e4e987c4e2883371ff5855b836c826fd9d4840c"
 dependencies = [
  "arm-gic",
  "cfg-if",
@@ -497,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_depex"
-version = "20.0.3"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58eef131032fbeeccd06e7b065bfa6da6b603557bf3c088434750c88bdd2980"
+checksum = "5bb1df7ac195cd528836db225d846855c7fe5e8f2e22b1ab7e1bd01db6a3a4a5"
 dependencies = [
  "log",
  "r-efi",
@@ -518,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "patina_macro"
-version = "20.0.3"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a708ee406163ef8e3db9512c050e8df42760e281919cd584a5cfc219b158c7a9"
+checksum = "c87b8874f14ad5c8223a001122400b95a7e0b7b68cbf2b82fb30adcdfe1b2b21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -530,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "patina_mm"
-version = "20.0.3"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef02cddc02e410f1f793add30b2be0d271ce2a88ba42343686fdf616810bbd7"
+checksum = "9ece52cea145be9b54d8e345819e9cdcf1a5dab956d01aaa7b0a6a4ff483fbfa"
 dependencies = [
  "cfg-if",
  "log",
@@ -567,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "patina_performance"
-version = "20.0.3"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f3ea900f25daf5baa24ae5984551a15e70658e2d092420da7a2eed54d2890b"
+checksum = "db2a857558253b1826acffe91ce4d250ed39de53410859420dd3b9c86d918a6f"
 dependencies = [
  "log",
  "mu_rust_helpers",
@@ -583,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "patina_samples"
-version = "20.0.3"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63c7eb638c552693f017ae6d3d3fc039f2262f0524194668b97630b0b38723bd"
+checksum = "d05d7dec2f149157eb70b22dca0386d4ce9a15a27daffb390c3bea488f91800f"
 dependencies = [
  "log",
  "patina",
@@ -595,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "patina_smbios"
-version = "20.0.3"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51b3a58f6b5a8bd40fe3ebe1c51559ce9ad274e27804c8c144967bc3f6d145e"
+checksum = "4bd14f0ebb21e9cc6a541c9c3a911ae286f4a29f3e10d6c759e3464ad914fc85"
 dependencies = [
  "log",
  "patina",
@@ -610,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "patina_stacktrace"
-version = "20.0.3"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ab3dc0a27b7f56a5ef5a8f03b258615d19cfdbd5c83f0d86da303c1927bd6a"
+checksum = "b8cfe11646bbc85c583a789563aedca764f4977d37bd33019de5eacf8c9e5e6a"
 dependencies = [
  "cfg-if",
  "log",
@@ -647,7 +658,7 @@ checksum = "8bb0fd6580eeed0103c054e3fba2c2618ff476943762f28a645b63b8692b21c9"
 
 [[package]]
 name = "qemu_dxe_core"
-version = "2.2.12"
+version = "2.2.13"
 dependencies = [
  "log",
  "patina",
@@ -668,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -882,17 +893,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "uefi_corosensei"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e826eb77ff5d1fb028ad17fe147e777e9e5f221b7faa43175160966a9b182f84"
-dependencies = [
- "autocfg",
- "cfg-if",
- "scopeguard",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,9 +900,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "uuid"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 
 [[package]]
 name = "volatile"
@@ -944,18 +944,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qemu_dxe_core"
-version = "2.2.12"
+version = "2.2.13"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Description

Updates patina crates to 20.1.0.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

I observed three issues in testing.

1. https://github.com/OpenDevicePartnership/patina-dxe-core-qemu/issues/134
  - Addressed in: https://github.com/OpenDevicePartnership/patina/commit/de906aba48b9749177ee3fbd27756bd8a411dfc0
  - Not included in this PR (therefore, will not be in patina-dxe-core-qemu v2.2.13)
    - SBSA boot has succeeded in some cases without the change
    - It will be picked up in the next patina release, that should be made by tomorrow
    - If you encounter the issue, build against the latest patina code (including the commit linked above)
2. https://github.com/OpenDevicePartnership/patina-dxe-core-qemu/issues/135
  - Addressed in: https://github.com/OpenDevicePartnership/patina-dxe-core-qemu/commit/f5495a9444e70f7948b6a03047dae5f09c6a8547
    - That change is included in this patina-dxe-core-qemu release
3. SBSA failed to initialize the display (e.g. show boot logo, render EFI shell, etc.). That issue was due to a stale protocol DEPEX (`36D5E70D-21AB-47E2-8F31-5D48F88B2C56` which is `gSbsaPolicyDataGFXGuid` which was removed in https://github.com/OpenDevicePartnership/patina-qemu/commit/788b8187405c0850bfeb06e74adc06949f235d2c) in my local SBSA workspace.
    - No code changes are needed, but if you encounter that issue, please try a clean QemuSbsaPkg build.

## Integration Instructions

- Review the patina-dxe-core-qemu v2.2.13 release notes