### PR TITLE
Temporarily revert "Enable ACPI component(s)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,15 +282,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mu_rust_helpers"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,9 +351,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "patina"
-version = "20.1.0"
+version = "20.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22e6f05f2806a6705f481d120587b1d99be044c1fbbef6108f1d18b7a46c09"
+checksum = "7e020ae8edf2946687199058930d264e823f27156abf55da2e43ad75647780b2"
 dependencies = [
  "cfg-if",
  "fallible-streaming-iterator",
@@ -380,22 +371,6 @@ dependencies = [
  "uart_16550",
  "uuid",
  "x86_64",
- "zerocopy",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "patina_acpi"
-version = "20.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8cc2a69c29cd0abc7c62a6f653e36f094dc767f17417401973c850e128454a"
-dependencies = [
- "log",
- "memoffset",
- "patina",
- "r-efi",
- "scroll",
- "spin",
  "zerocopy",
  "zerocopy-derive",
 ]
@@ -543,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "patina_macro"
-version = "20.1.0"
+version = "20.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87b8874f14ad5c8223a001122400b95a7e0b7b68cbf2b82fb30adcdfe1b2b21"
+checksum = "a708ee406163ef8e3db9512c050e8df42760e281919cd584a5cfc219b158c7a9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -676,7 +651,6 @@ version = "2.2.12"
 dependencies = [
  "log",
  "patina",
- "patina_acpi",
  "patina_adv_logger",
  "patina_debugger",
  "patina_dxe_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ path = "src/lib.rs"
 log = { version = "^0.4", default-features = false, features = [
     "release_max_level_info",
 ] }
-patina_acpi = { version = "20" }
 patina_adv_logger = { version = "20" }
 patina_debugger = { version = "20" }
 patina_dxe_core = { version = "20" }

--- a/bin/q35_dxe_core.rs
+++ b/bin/q35_dxe_core.rs
@@ -111,7 +111,6 @@ impl ComponentInfo for Q35 {
         add.component(patina_performance::component::performance::Performance);
         add.component(patina_smbios::component::SmbiosProvider::new(3, 9));
         add.component(q35_services::smbios_platform::Q35SmbiosPlatform::new());
-        add.component(patina_acpi::component::AcpiComponent::default());
         add.component(patina::test::TestRunner::default().with_callback(|test_name, err_msg| {
             log::error!("Test {} failed: {}", test_name, err_msg);
             qemu_exit::X86::new(0xf4, 0x1).exit_failure();

--- a/bin/sbsa_dxe_core.rs
+++ b/bin/sbsa_dxe_core.rs
@@ -79,7 +79,6 @@ impl ComponentInfo for Sbsa {
         }));
         add.component(patina_performance::component::performance_config_provider::PerformanceConfigurationProvider);
         add.component(patina_performance::component::performance::Performance);
-        add.component(patina_acpi::component::AcpiComponent::default());
     }
 
     fn configs(mut add: Add<Config>) {


### PR DESCRIPTION
## Description

Resolves #135 

This reverts commit fa1609124bf0813feba270fb16c4540d1cb025c6 due to a boot hang observed with the change.

Once this is root caused, the change can be re-applied.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Q35 and SBSA boot to EFI shell

## Integration Instructions

- The Patina ACPI component won't be in the Patina DXE Core QEMU binary