### PR TITLE
Q35/SBSA SMBIOS platforms: adopt typed records from patina #1501

### DIFF
--- a/src/q35/component/service/smbios_platform.rs
+++ b/src/q35/component/service/smbios_platform.rs
@@ -24,6 +24,10 @@ use patina_smbios::{
     smbios_record::{
         Type0PlatformFirmwareInformation, Type1SystemInformation, Type2BaseboardInformation, Type3SystemEnclosure,
     },
+    smbios_types::{
+        BiosCharacteristics, BiosCharacteristicsExt1, BiosCharacteristicsExt2, BoardType, BootUpState,
+        ExtendedBiosRomSize, FeatureFlags, PowerSupplyState, SecurityStatus, ThermalState, WakeUpType,
+    },
 };
 
 /// Q35 platform SMBIOS component that populates and publishes SMBIOS tables.
@@ -60,20 +64,14 @@ impl Q35SmbiosPlatform {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF, // 16MB
-            // BIOS Characteristics (SMBIOS spec 7.1.1)
-            // Bit 3: BIOS Characteristics are supported
-            characteristics: 0x08,
-            // BIOS Characteristics Extension Byte 1 (SMBIOS spec 7.1.2.1)
-            // Bit 0: ACPI supported, Bit 1: USB Legacy supported
-            characteristics_ext1: 0x03,
-            // BIOS Characteristics Extension Byte 2 (SMBIOS spec 7.1.2.2)
-            // Bit 0: BIOS Boot Specification supported, Bit 1: Function key-initiated network boot supported
-            characteristics_ext2: 0x03,
+            characteristics: BiosCharacteristics::from_bits(0x08),
+            characteristics_ext1: BiosCharacteristicsExt1::from_bits(0x03),
+            characteristics_ext2: BiosCharacteristicsExt2::from_bits(0x03),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: 0,
+            extended_bios_rom_size: ExtendedBiosRomSize::new(),
             string_pool: vec![
                 String::from("Patina Firmware"),
                 String::from(env!("CARGO_PKG_VERSION")),
@@ -94,7 +92,7 @@ impl Q35SmbiosPlatform {
             version: 3,
             serial_number: 4,
             uuid: [0; 16],
-            wake_up_type: 0x06, // Power Switch
+            wake_up_type: WakeUpType::PowerSwitch,
             sku_number: 5,
             family: 6,
             string_pool: vec![
@@ -119,10 +117,10 @@ impl Q35SmbiosPlatform {
             version: 2,
             serial_number: 3,
             asset_tag_number: 4,
-            bootup_state: 0x03,
-            power_supply_state: 0x03,
-            thermal_state: 0x03,
-            security_status: 0x02,
+            bootup_state: BootUpState::Safe,
+            power_supply_state: PowerSupplyState::Safe,
+            thermal_state: ThermalState::Safe,
+            security_status: SecurityStatus::Unknown,
             oem_defined: 0x00000000,
             height: 0x00,
             number_of_power_cords: 0x01,
@@ -152,10 +150,10 @@ impl Q35SmbiosPlatform {
             version: 3,
             serial_number: 4,
             asset_tag: 5,
-            feature_flags: 0x01, // Board is a hosting board
+            feature_flags: FeatureFlags::new().with_hosting_board(true),
             location_in_chassis: 6,
             chassis_handle: type3_handle,
-            board_type: 0x0A, // Motherboard
+            board_type: BoardType::Motherboard,
             contained_object_handles: 0,
             string_pool: vec![
                 String::from("Example Corporation"),

--- a/src/sbsa/component/service/smbios_platform.rs
+++ b/src/sbsa/component/service/smbios_platform.rs
@@ -21,6 +21,14 @@ use patina_smbios::{
         Type4ProcessorInformation, Type7CacheInformation, Type16PhysicalMemoryArray, Type17MemoryDevice,
         Type19MemoryArrayMappedAddress,
     },
+    smbios_types::{
+        AssociativityField, BiosCharacteristics, BiosCharacteristicsExt1, BiosCharacteristicsExt2, BoardType,
+        BootUpState, CacheConfiguration, CacheSize, CacheSize2, CacheSramTypeData, ErrorCorrectionType,
+        ExtendedBiosRomSize, FeatureFlags, MemoryArrayLocation, MemoryArrayUse, MemoryCapability,
+        MemoryDeviceAttributes, MemoryDeviceTechnology, MemoryDeviceType, MemoryDeviceTypeDetails, MemoryFormFactor,
+        PowerSupplyState, ProcessorCharacteristics, ProcessorFamilyData, ProcessorInformationStatus, ProcessorTypeData,
+        ProcessorUpgrade, ProcessorVoltage, SecurityStatus, SystemCacheType, ThermalState, WakeUpType,
+    },
 };
 
 /// SBSA platform SMBIOS record provider.
@@ -47,14 +55,14 @@ impl SbsaSmbiosPlatform {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: 0x08,
-            characteristics_ext1: 0x03,
-            characteristics_ext2: 0x03,
+            characteristics: BiosCharacteristics::from_bits(0x08),
+            characteristics_ext1: BiosCharacteristicsExt1::from_bits(0x03),
+            characteristics_ext2: BiosCharacteristicsExt2::from_bits(0x03),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: 0,
+            extended_bios_rom_size: ExtendedBiosRomSize::new(),
             string_pool: vec![
                 String::from("Patina Firmware"),
                 String::from(env!("CARGO_PKG_VERSION")),
@@ -77,7 +85,7 @@ impl SbsaSmbiosPlatform {
             version: 3,
             serial_number: 4,
             uuid: [0; 16],
-            wake_up_type: 0x06,
+            wake_up_type: WakeUpType::PowerSwitch,
             sku_number: 5,
             family: 6,
             string_pool: vec![
@@ -103,10 +111,10 @@ impl SbsaSmbiosPlatform {
             version: 2,
             serial_number: 3,
             asset_tag_number: 4,
-            bootup_state: 0x03,
-            power_supply_state: 0x03,
-            thermal_state: 0x03,
-            security_status: 0x02,
+            bootup_state: BootUpState::Safe,
+            power_supply_state: PowerSupplyState::Safe,
+            thermal_state: ThermalState::Safe,
+            security_status: SecurityStatus::Unknown,
             oem_defined: 0x00000000,
             height: 0x00,
             number_of_power_cords: 0x01,
@@ -136,10 +144,10 @@ impl SbsaSmbiosPlatform {
             version: 3,
             serial_number: 4,
             asset_tag: 5,
-            feature_flags: 0x01,
+            feature_flags: FeatureFlags::new().with_hosting_board(true),
             location_in_chassis: 6,
             chassis_handle: type3_handle,
-            board_type: 0x0A,
+            board_type: BoardType::Motherboard,
             contained_object_handles: 0,
             string_pool: vec![
                 String::from("Example Corporation"),
@@ -160,17 +168,17 @@ impl SbsaSmbiosPlatform {
         let l1_cache = Type7CacheInformation {
             header: SmbiosTableHeader::new(7, 0, SMBIOS_HANDLE_PI_RESERVED),
             socket_designation: 1,
-            cache_configuration: 0x0180, // L1, enabled, write-back
-            maximum_cache_size: 64,      // 64 KB
-            installed_size: 64,
-            supported_sram_type: 0x0002, // Unknown
-            current_sram_type: 0x0002,
+            cache_configuration: CacheConfiguration::from_bits(0x0180), // L1, enabled, write-back
+            maximum_cache_size: CacheSize::from_bits(64),               // 64 KB
+            installed_size: CacheSize::from_bits(64),
+            supported_sram_type: CacheSramTypeData::from_bits(0x0002), // Unknown
+            current_sram_type: CacheSramTypeData::from_bits(0x0002),
             cache_speed: 0,
-            error_correction_type: 0x05, // Single-bit ECC
-            system_cache_type: 0x05,     // Unified
-            associativity: 0x06,         // 8-way
-            maximum_cache_size2: 64,
-            installed_cache_size2: 64,
+            error_correction_type: ErrorCorrectionType::SingleBitEcc,
+            system_cache_type: SystemCacheType::Unified,
+            associativity: AssociativityField::FullyAssociative,
+            maximum_cache_size2: CacheSize2::from_bits(64),
+            installed_size2: CacheSize2::from_bits(64),
             string_pool: vec![String::from("L1 Cache")],
         };
 
@@ -186,17 +194,17 @@ impl SbsaSmbiosPlatform {
         let l2_cache = Type7CacheInformation {
             header: SmbiosTableHeader::new(7, 0, SMBIOS_HANDLE_PI_RESERVED),
             socket_designation: 1,
-            cache_configuration: 0x0181, // L2, enabled, write-back
-            maximum_cache_size: 256,     // 256 KB
-            installed_size: 256,
-            supported_sram_type: 0x0002,
-            current_sram_type: 0x0002,
+            cache_configuration: CacheConfiguration::from_bits(0x0181), // L2, enabled, write-back
+            maximum_cache_size: CacheSize::from_bits(256),              // 256 KB
+            installed_size: CacheSize::from_bits(256),
+            supported_sram_type: CacheSramTypeData::from_bits(0x0002),
+            current_sram_type: CacheSramTypeData::from_bits(0x0002),
             cache_speed: 0,
-            error_correction_type: 0x05, // Single-bit ECC
-            system_cache_type: 0x05,     // Unified
-            associativity: 0x06,         // 8-way
-            maximum_cache_size2: 256,
-            installed_cache_size2: 256,
+            error_correction_type: ErrorCorrectionType::SingleBitEcc,
+            system_cache_type: SystemCacheType::Unified,
+            associativity: AssociativityField::FullyAssociative,
+            maximum_cache_size2: CacheSize2::from_bits(256),
+            installed_size2: CacheSize2::from_bits(256),
             string_pool: vec![String::from("L2 Cache")],
         };
 
@@ -213,17 +221,17 @@ impl SbsaSmbiosPlatform {
         let processor_info = Type4ProcessorInformation {
             header: SmbiosTableHeader::new(4, 0, SMBIOS_HANDLE_PI_RESERVED),
             socket_designation: 1,
-            processor_type: 0x03,   // Central Processor
+            processor_type: ProcessorTypeData::CentralProcessor,
             processor_family: 0xFE, // Use processor_family2
             processor_manufacturer: 2,
             processor_id: [0u8; 8],
             processor_version: 3,
-            voltage: 0x80,     // Legacy mode, voltage unknown
-            external_clock: 0, // Unknown
+            voltage: ProcessorVoltage::from_bits(0x80), // Legacy mode, voltage unknown
+            external_clock: 0,                          // Unknown
             max_speed: 2000,
             current_speed: 2000,
-            status: 0x41,            // CPU Enabled, Populated
-            processor_upgrade: 0x06, // None
+            status: ProcessorInformationStatus::from_bits(0x41), // CPU Enabled, Populated
+            processor_upgrade: ProcessorUpgrade::NoUpgrade,
             l1_cache_handle,
             l2_cache_handle,
             l3_cache_handle: 0xFFFF, // Not provided
@@ -233,8 +241,8 @@ impl SbsaSmbiosPlatform {
             core_count: 1,
             core_enabled: 1,
             thread_count: 1,
-            processor_characteristics: 0x04, // 64-bit capable
-            processor_family2: 0x0100,       // ARMv8
+            processor_characteristics: ProcessorCharacteristics::from_bits(0x04), // 64-bit capable
+            processor_family2: ProcessorFamilyData::ARMv8,
             core_count2: 1,
             core_enabled2: 1,
             thread_count2: 1,
@@ -256,9 +264,9 @@ impl SbsaSmbiosPlatform {
         // Type 16: Physical Memory Array
         let memory_array = Type16PhysicalMemoryArray {
             header: SmbiosTableHeader::new(16, 0, SMBIOS_HANDLE_PI_RESERVED),
-            location: 0x03,                          // System board
-            use_field: 0x03,                         // System memory
-            memory_error_correction: 0x03,           // None
+            location: MemoryArrayLocation::SystemBoard,
+            use_field: MemoryArrayUse::SystemMemory,
+            memory_error_correction: ErrorCorrectionType::NoEcc,
             maximum_capacity: 0x00100000,            // 1 GB in KB
             memory_error_information_handle: 0xFFFE, // Not provided
             number_of_memory_devices: 1,
@@ -282,26 +290,26 @@ impl SbsaSmbiosPlatform {
             memory_error_information_handle: 0xFFFE, // Not provided
             total_width: 64,
             data_width: 64,
-            size: 0x0400,      // 1024 MB
-            form_factor: 0x09, // DIMM
+            size: 0x0400, // 1024 MB
+            form_factor: MemoryFormFactor::Dimm,
             device_set: 0,
             device_locator: 1,
             bank_locator: 2,
-            memory_type: 0x1A,   // DDR4
-            type_detail: 0x0080, // Synchronous
+            memory_type: MemoryDeviceType::Ddr4,
+            type_detail: MemoryDeviceTypeDetails::from_bits(0x0080), // Synchronous
             speed: 3200,
             manufacturer: 3,
             serial_number: 4,
             asset_tag: 5,
             part_number: 6,
-            attributes: 0x01, // Single rank
+            attributes: MemoryDeviceAttributes::from_bits(0x01), // Single rank
             extended_size: 0,
             configured_memory_clock_speed: 3200,
             minimum_voltage: 1200,
             maximum_voltage: 1200,
             configured_voltage: 1200,
-            memory_technology: 0x02,                  // DRAM
-            memory_operating_mode_capability: 0x0004, // Volatile
+            memory_technology: MemoryDeviceTechnology::Unknown,
+            memory_operating_mode_capability: MemoryCapability::from_bits(0x0004), // Volatile
             firmware_version: 7,
             module_manufacturer_id: 0,
             module_product_id: 0,


### PR DESCRIPTION
> ⛔ **Blocked on:** [patina#1501](https://github.com/OpenDevicePartnership/patina/pull/1501)
> merging + a `patina_smbios` release. The Rust CI on this branch is expected
> to fail until then — the typed records (`SecurityStatus`, `FeatureFlags`,
> `BoardType`, etc.) it adopts don't exist on the published `patina_smbios = "21"`.
> Once a new patina release ships, this PR will bump the dep version and re-run
> CI cleanly.

## Description

Companion to [patina#1501](https://github.com/OpenDevicePartnership/patina/pull/1501),
which switches \`patina_smbios\` Type 0 / 1 / 2 / 3 / 4 / 7 / 16 / 17 / 19
records from raw integers to typed bitfields and enums. This PR ports the Q35
and SBSA SMBIOS platform components onto those typed records.

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

QEMU Q35 boot of the Rust DXE Core against patina#1501; \`q35_smbios_ffi_test\`
passes against the typed records and the system boots to the UEFI shell.

## Integration Instructions

Merge after patina#1501 lands and the corresponding \`patina_smbios\` version is
published, then bump the \`patina_smbios\` dependency in \`Cargo.toml\`.