### PR TITLE
Q35: Integrate patina_sre + BootDispatcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,9 +351,8 @@ checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "patina"
-version = "21.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f11549235c579955a9eade3451a3e9c9ed4f4106dc50b61e1a7e3d8667bf0ac"
+version = "21.0.4"
+source = "git+https://github.com/kat-perez/patina?branch=kat-perez%2Fsre-base#afb99c386a18d866cc08f71647659c2b6be81f0b"
 dependencies = [
  "cfg-if",
  "compile-time",
@@ -365,7 +364,7 @@ dependencies = [
  "log",
  "mu_rust_helpers",
  "num-traits",
- "patina_macro",
+ "patina_macro 21.0.4",
  "r-efi",
  "safe-mmio",
  "scroll",
@@ -403,6 +402,20 @@ dependencies = [
  "mu_rust_helpers",
  "patina",
  "patina_test",
+ "r-efi",
+ "spin",
+ "zerocopy",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "patina_boot"
+version = "0.1.0"
+source = "git+https://github.com/OpenDevicePartnership/patina-components?branch=main#1bcdd7a34b7558a38dacb7e2db069ff73e610188"
+dependencies = [
+ "log",
+ "patina",
+ "patina_macro 21.0.2",
  "r-efi",
  "spin",
  "zerocopy",
@@ -534,9 +547,31 @@ dependencies = [
 
 [[package]]
 name = "patina_macro"
+version = "21.0.2"
+source = "git+https://github.com/OpenDevicePartnership/patina?branch=feature%2Fpatina-boot#adc19cdf6344684796c599aa512c62b227068031"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "uuid",
+]
+
+[[package]]
+name = "patina_macro"
 version = "21.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d520271070a33fe6b454ab5a7f136b88963cbebcfffb3b76d017b3280b1845c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "uuid",
+]
+
+[[package]]
+name = "patina_macro"
+version = "21.0.4"
+source = "git+https://github.com/kat-perez/patina?branch=kat-perez%2Fsre-base#afb99c386a18d866cc08f71647659c2b6be81f0b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -569,6 +604,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "patina_nvme"
+version = "0.1.0"
+source = "git+https://github.com/kat-perez/patina-components?branch=kat-perez%2Fpatina-nvme#6e4608e136b6bdab5b5e64e6851f7afadb829c7e"
+dependencies = [
+ "log",
+ "patina",
+ "r-efi",
+]
+
+[[package]]
 name = "patina_paging"
 version = "11.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +623,16 @@ dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
  "log",
+]
+
+[[package]]
+name = "patina_partition"
+version = "0.1.0"
+source = "git+https://github.com/kat-perez/patina-components?branch=kat-perez%2Fpatina-partition#3937db8ed783678d089ffa547fb38ec20c32ffcb"
+dependencies = [
+ "log",
+ "patina",
+ "r-efi",
 ]
 
 [[package]]
@@ -597,6 +652,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "patina_ram_disk"
+version = "0.1.0"
+source = "git+https://github.com/kat-perez/patina-components?branch=kat-perez%2Fpatina-ram-disk#75dcf21347f053159a7d4b88d920d94dcef016a7"
+dependencies = [
+ "patina",
+ "r-efi",
+]
+
+[[package]]
 name = "patina_samples"
 version = "21.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,7 +668,7 @@ checksum = "3d460371dc827972748895d0a6a0fb32651bc58684581394938b77f2e06ca58a"
 dependencies = [
  "log",
  "patina",
- "patina_macro",
+ "patina_macro 21.0.3",
  "patina_smbios",
 ]
 
@@ -616,11 +680,25 @@ checksum = "0017dbf39385eb828a9447e7c6db09bfe03031b0ae9846316c28aab11bf6388f"
 dependencies = [
  "log",
  "patina",
- "patina_macro",
+ "patina_macro 21.0.3",
  "r-efi",
  "spin",
  "zerocopy",
  "zerocopy-derive",
+]
+
+[[package]]
+name = "patina_sre"
+version = "0.1.0"
+source = "git+https://github.com/kat-perez/odp-platform-common?branch=kat-perez%2Fpatina-sre#b140afee5cf6552b4d6c071b7d280127bf4d88f5"
+dependencies = [
+ "log",
+ "patina",
+ "patina_boot",
+ "patina_nvme",
+ "patina_partition",
+ "patina_ram_disk",
+ "r-efi",
 ]
 
 [[package]]
@@ -642,7 +720,7 @@ dependencies = [
  "linkme",
  "log",
  "patina",
- "patina_macro",
+ "patina_macro 21.0.3",
  "r-efi",
  "spin",
 ]
@@ -682,6 +760,7 @@ dependencies = [
  "patina",
  "patina_acpi",
  "patina_adv_logger",
+ "patina_boot",
  "patina_debugger",
  "patina_dxe_core",
  "patina_ffs_extractors",
@@ -689,6 +768,7 @@ dependencies = [
  "patina_performance",
  "patina_samples",
  "patina_smbios",
+ "patina_sre",
  "patina_stacktrace",
  "patina_test",
  "qemu-exit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,13 @@ patina_performance = { version = "21" }
 patina_samples = { version = "21" }
 patina_smbios = { version = "21" }
 patina_test = { version = "21", features = ["test-runner"] }
-patina = { version = "21" }
+patina = { version = "21", features = ["unstable-device-path"] }
 patina_ffs_extractors = { version = "21" }
 patina_stacktrace = { version = "21" }
+# SRE orchestrator + its supporting helpers. Currently pulled from kat-perez git branches
+# until the corresponding releases ship; see the [patch] block at the bottom of this file.
+patina_boot = { git = "https://github.com/OpenDevicePartnership/patina-components", branch = "main" }
+patina_sre = { git = "https://github.com/kat-perez/odp-platform-common", branch = "kat-perez/patina-sre" }
 r-efi = { version = "^5", default-features = false }
 x86_64 = { version = "=0.15.2", default-features = false, features = [
   "instructions"
@@ -58,3 +62,20 @@ std = []
 build_debugger = ["patina_dxe_core/debugger_reload"]
 enable_debugger = ["build_debugger"]
 exit_on_patina_test_failure = ["qemu-exit"]
+# Force the SRE recovery path on every boot (uses patina_sre::AlwaysSre). Without this feature
+# the orchestrator defaults to patina_sre::NeverSre and always takes the normal boot path.
+# Useful for QEMU validation of the SRE flow without needing hotkey hardware.
+force_sre = []
+
+# Force every patina dep (this crate's `version = "21"`, plus transitive git deps coming in
+# via patina_boot / patina_sre) onto a single source — the kat-perez/sre-base branch that
+# combines feature/patina-boot with the EFI_RAM_DISK_PROTOCOL binding from patina#1490.
+# Without this, cargo resolves two patina versions (crates.io and git) and SreBootManager
+# can't be added as a component because the IntoComponent trait is different per copy.
+# Drop both patch entries once #1490 / feature/patina-boot merge and a patina release ships
+# the required APIs.
+[patch.crates-io]
+patina = { git = "https://github.com/kat-perez/patina", branch = "kat-perez/sre-base" }
+
+[patch."https://github.com/OpenDevicePartnership/patina"]
+patina = { git = "https://github.com/kat-perez/patina", branch = "kat-perez/sre-base" }

--- a/bin/q35_dxe_core.rs
+++ b/bin/q35_dxe_core.rs
@@ -12,12 +12,19 @@
 
 use core::{ffi::c_void, panic::PanicInfo};
 use patina::{log::Format, serial::uart::Uart16550};
+use patina::device_path::{node_defs::EndEntire, paths::DevicePathBuf};
 use patina_adv_logger::{
     component::AdvancedLoggerComponent,
     logger::{AdvancedLogger, TargetFilter},
 };
+use patina_boot::BootDispatcher;
 use patina_dxe_core::*;
 use patina_ffs_extractors::CompositeSectionExtractor;
+#[cfg(feature = "force_sre")]
+use patina_sre::AlwaysSre as ConfiguredHotkey;
+#[cfg(not(feature = "force_sre"))]
+use patina_sre::NeverSre as ConfiguredHotkey;
+use patina_sre::SreBootManager;
 use patina_stacktrace::StackTrace;
 use qemu_resources::q35::component::service as q35_services;
 extern crate alloc;
@@ -121,7 +128,25 @@ impl ComponentInfo for Q35 {
             #[cfg(feature = "exit_on_patina_test_failure")]
             qemu_exit::X86::new(0xf4, 0x1).exit_failure();
         }));
+
+        // SRE boot orchestrator. Device paths are placeholders (single EndEntire node) for
+        // initial integration: at runtime the helper protocol lookups will return NOT_FOUND
+        // and the orchestrator logs each failure — useful for confirming the component is
+        // wired and reachable without needing a real boot partition / NVMe controller in QEMU.
+        // Real device paths land alongside the QEMU disk image that hosts the SRE WIM.
+        add.component(BootDispatcher::new(SreBootManager::new(
+            placeholder_device_path(),
+            placeholder_device_path(),
+            "\\SRE\\winvos.wim",
+            ConfiguredHotkey,
+        )));
     }
+}
+
+/// Build a placeholder `DevicePathBuf` containing only an EndEntire terminator node.
+/// Replace with real device paths once the QEMU SRE disk image is in place.
+fn placeholder_device_path() -> DevicePathBuf {
+    DevicePathBuf::from_device_path_node_iter(core::iter::once(EndEntire))
 }
 
 impl PlatformInfo for Q35 {


### PR DESCRIPTION
## Description

Wires \`patina_sre::SreBootManager\` into the Q35 DXE-core component list via \`patina_boot::BootDispatcher\`. This gives Q35 an end-to-end SRE boot orchestrator that can be exercised under QEMU once the underlying dependencies land — see Status below.

The integration:

- Adds \`patina_boot\` and \`patina_sre\` as git deps in \`Cargo.toml\` (will move to versioned crates.io references once those releases ship).
- Registers \`BootDispatcher::new(SreBootManager::new(...))\` in \`Q35::components\`. Device paths are placeholder (single \`EndEntire\` node) for the initial wiring — at runtime the orchestrator's helper protocol lookups will return NOT_FOUND and each failure is logged, confirming the component is reachable without needing a real boot partition / NVMe controller in QEMU.
- Adds a \`force_sre\` build feature that swaps the orchestrator's \`HotkeySource\` from \`NeverSre\` (default — always normal path) to \`AlwaysSre\` (forces the SRE recovery path). Lets QEMU validation exercise the SRE flow without hotkey hardware.

A \`[patch]\` block in \`Cargo.toml\` redirects every \`patina\` dep (this crate's \`version = \"21\"\` plus transitive git refs from \`patina_boot\` / \`patina_sre\`) onto a single combined branch (\`kat-perez/sre-base\` = upstream \`feature/patina-boot\` + the EFI_RAM_DISK_PROTOCOL binding from patina#1490). Without this unification cargo sees two \`patina\` versions and \`IntoComponent\` resolution fails.

## Status

**Draft.** Depends on the following PRs landing first, in approximately this order:

1. [patina#1490](https://github.com/OpenDevicePartnership/patina/pull/1490) — \`EFI_RAM_DISK_PROTOCOL\` binding in \`sdk/patina\`.
2. [patina-components#11](https://github.com/OpenDevicePartnership/patina-components/pull/11), [#12](https://github.com/OpenDevicePartnership/patina-components/pull/12), [#13](https://github.com/OpenDevicePartnership/patina-components/pull/13) — \`patina_nvme\` / \`patina_partition\` / \`patina_ram_disk\` helper crates.
3. [odp-platform-common#91](https://github.com/OpenDevicePartnership/odp-platform-common/pull/91) — \`patina_sre\` crate itself.
4. A \`patina\` release containing the ram-disk binding so the \`[patch]\` block can come out.

## How This Was Tested

\`cargo build --bin qemu_q35_dxe_core --target x86_64-unknown-uefi --release --features x64\` — produces a 974 KiB Q35 \`.efi\` against the default \`NeverSre\` hotkey. Adding \`--features force_sre\` produces a 983 KiB binary that takes the SRE recovery path on every boot.

QEMU integration end-to-end (\`Stuart\` build of \`QemuQ35Pkg\` against our newly-built Patina binary, boot under QEMU, observe log output for both paths) is the next step.

## Integration Instructions

Build with the SRE-integrated Patina binary as a one-liner:

\`\`\`bash
cargo build --bin qemu_q35_dxe_core --target x86_64-unknown-uefi --release --features x64           # normal path (NeverSre)
cargo build --bin qemu_q35_dxe_core --target x86_64-unknown-uefi --release --features x64,force_sre # SRE path (AlwaysSre)
\`\`\`

Then run through the patina-qemu \`QemuQ35Pkg\` build flow as usual — the Patina binary swap is the only change.