### PR TITLE
[arm-virt] Adding an ARM-Virt build target

### DIFF
--- a/.github/workflows/binary-size-report.yml
+++ b/.github/workflows/binary-size-report.yml
@@ -34,11 +34,9 @@ jobs:
           cargo make q35
           cargo make ovmf
           cargo make sbsa
-          cargo make armvirt
           cargo make q35-release
           cargo make ovmf-release
           cargo make sbsa-release
-          cargo make armvirt-release
 
       - name: Get Base Branch (${{ github.base_ref }}) Sizes
         id: size-base
@@ -66,11 +64,9 @@ jobs:
           cargo make q35
           cargo make ovmf
           cargo make sbsa
-          cargo make armvirt
           cargo make q35-release
           cargo make ovmf-release
           cargo make sbsa-release
-          cargo make armvirt-release
 
       - name: Get PR Branch (${{ github.head_ref }}) Sizes
         id: size-pr

--- a/.github/workflows/binary-size-report.yml
+++ b/.github/workflows/binary-size-report.yml
@@ -34,9 +34,11 @@ jobs:
           cargo make q35
           cargo make ovmf
           cargo make sbsa
+          cargo make armvirt
           cargo make q35-release
           cargo make ovmf-release
           cargo make sbsa-release
+          cargo make armvirt-release
 
       - name: Get Base Branch (${{ github.base_ref }}) Sizes
         id: size-base
@@ -64,9 +66,11 @@ jobs:
           cargo make q35
           cargo make ovmf
           cargo make sbsa
+          cargo make armvirt
           cargo make q35-release
           cargo make ovmf-release
           cargo make sbsa-release
+          cargo make armvirt-release
 
       - name: Get PR Branch (${{ github.head_ref }}) Sizes
         id: size-pr

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -54,6 +54,12 @@ jobs:
           cp target/aarch64-unknown-uefi/debug/qemu_sbsa_dxe_core.efi artifacts/debug/qemu_sbsa_dxe_core.efi
           cp target/aarch64-unknown-uefi/debug/qemu_sbsa_dxe_core.pdb artifacts/debug/qemu_sbsa_dxe_core.pdb
 
+      - name: Build Arm Virt Debug
+        run: |
+          cargo make armvirt
+          cp target/aarch64-unknown-uefi/debug/qemu_armvirt_dxe_core.efi artifacts/debug/qemu_armvirt_dxe_core.efi
+          cp target/aarch64-unknown-uefi/debug/qemu_armvirt_dxe_core.pdb artifacts/debug/qemu_armvirt_dxe_core.pdb
+
       - name: Build Q35 Release
         run: |
           cargo make q35-release
@@ -72,6 +78,12 @@ jobs:
           cp target/aarch64-unknown-uefi/release/qemu_sbsa_dxe_core.efi artifacts/release/qemu_sbsa_dxe_core.efi
           cp target/aarch64-unknown-uefi/release/qemu_sbsa_dxe_core.pdb artifacts/release/qemu_sbsa_dxe_core.pdb
 
+      - name: Build Arm Virt Release
+        run: |
+          cargo make armvirt-release
+          cp target/aarch64-unknown-uefi/release/qemu_armvirt_dxe_core.efi artifacts/release/qemu_armvirt_dxe_core.efi
+          cp target/aarch64-unknown-uefi/release/qemu_armvirt_dxe_core.pdb artifacts/release/qemu_armvirt_dxe_core.pdb
+
       - name: Build Q35 Debug (Debugger)
         run: |
           cargo make q35 --features enable_debugger
@@ -89,6 +101,12 @@ jobs:
           cargo make sbsa --features enable_debugger
           cp target/aarch64-unknown-uefi/debug/qemu_sbsa_dxe_core.efi artifacts/debug/debugger/qemu_sbsa_dxe_core.efi
           cp target/aarch64-unknown-uefi/debug/qemu_sbsa_dxe_core.pdb artifacts/debug/debugger/qemu_sbsa_dxe_core.pdb
+
+      - name: Build Arm Virt Debug (Debugger)
+        run: |
+          cargo make armvirt --features enable_debugger
+          cp target/aarch64-unknown-uefi/debug/qemu_armvirt_dxe_core.efi artifacts/debug/debugger/qemu_armvirt_dxe_core.efi
+          cp target/aarch64-unknown-uefi/debug/qemu_armvirt_dxe_core.pdb artifacts/debug/debugger/qemu_armvirt_dxe_core.pdb
 
       - name: Upload Binaries
         if: ${{ github.event_name != 'release' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,11 @@ name = "qemu_ovmf_dxe_core"
 path = "bin/ovmf_dxe_core.rs"
 required-features = ["x64"]
 
+[[bin]]
+name = "qemu_virt_dxe_core"
+path = "bin/arm_virt_dxe_core.rs"
+required-features = ["aarch64"]
+
 [lib]
 name = "qemu_resources"
 path = "src/lib.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ path = "bin/ovmf_dxe_core.rs"
 required-features = ["x64"]
 
 [[bin]]
-name = "qemu_virt_dxe_core"
+name = "qemu_armvirt_dxe_core"
 path = "bin/arm_virt_dxe_core.rs"
 required-features = ["aarch64"]
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -471,6 +471,16 @@ description = """Builds the RELEASE OVMF UEFI firmware."""
 env = { CARGO_BIN_NAME = "qemu_ovmf_dxe_core", "RUSTC_PROFILE" = "release", CARGO_BIN_TARGET = "x86_64-unknown-uefi", CARGO_BIN_FEATURES = "${BASE_FEATURES},x64,v1_resource_descriptor_support", CARGO_TARGET_X86_64_UNKNOWN_UEFI_RUSTFLAGS = "-C link-arg=/PDBALTPATH:qemu_ovmf_dxe_core.pdb" }
 run_task = "patch"
 
+[tasks.virt]
+description = """Builds the DEBUG VIRT UEFI firmware."""
+env = { CARGO_BIN_NAME = "qemu_virt_dxe_core", "RUSTC_PROFILE" = "dev", CARGO_BIN_TARGET = "aarch64-unknown-uefi", CARGO_BIN_FEATURES = "${BASE_FEATURES},aarch64,build_debugger", CARGO_TARGET_AARCH64_UNKNOWN_UEFI_RUSTFLAGS = "-C link-arg=/PDBALTPATH:qemu_virt_dxe_core.pdb" }
+run_task = "patch"
+
+[tasks.virt-release]
+description = """Builds the RELEASE VIRT UEFI firmware."""
+env = { CARGO_BIN_NAME = "qemu_virt_dxe_core", "RUSTC_PROFILE" = "release", CARGO_BIN_TARGET = "aarch64-unknown-uefi", CARGO_BIN_FEATURES = "${BASE_FEATURES},aarch64", CARGO_TARGET_AARCH64_UNKNOWN_UEFI_RUSTFLAGS = "-C link-arg=/PDBALTPATH:qemu_virt_dxe_core.pdb" }
+run_task = "patch"
+
 [tasks.doc]
 description = "Builds all rust documentation in the workspace. Example `cargo make doc`"
 command = "cargo"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -471,14 +471,14 @@ description = """Builds the RELEASE OVMF UEFI firmware."""
 env = { CARGO_BIN_NAME = "qemu_ovmf_dxe_core", "RUSTC_PROFILE" = "release", CARGO_BIN_TARGET = "x86_64-unknown-uefi", CARGO_BIN_FEATURES = "${BASE_FEATURES},x64,v1_resource_descriptor_support", CARGO_TARGET_X86_64_UNKNOWN_UEFI_RUSTFLAGS = "-C link-arg=/PDBALTPATH:qemu_ovmf_dxe_core.pdb" }
 run_task = "patch"
 
-[tasks.virt]
+[tasks.armvirt]
 description = """Builds the DEBUG VIRT UEFI firmware."""
-env = { CARGO_BIN_NAME = "qemu_virt_dxe_core", "RUSTC_PROFILE" = "dev", CARGO_BIN_TARGET = "aarch64-unknown-uefi", CARGO_BIN_FEATURES = "${BASE_FEATURES},aarch64,build_debugger", CARGO_TARGET_AARCH64_UNKNOWN_UEFI_RUSTFLAGS = "-C link-arg=/PDBALTPATH:qemu_virt_dxe_core.pdb" }
+env = { CARGO_BIN_NAME = "qemu_armvirt_dxe_core", "RUSTC_PROFILE" = "dev", CARGO_BIN_TARGET = "aarch64-unknown-uefi", CARGO_BIN_FEATURES = "${BASE_FEATURES},aarch64,build_debugger", CARGO_TARGET_AARCH64_UNKNOWN_UEFI_RUSTFLAGS = "-C link-arg=/PDBALTPATH:qemu_armvirt_dxe_core.pdb" }
 run_task = "patch"
 
-[tasks.virt-release]
+[tasks.armvirt-release]
 description = """Builds the RELEASE VIRT UEFI firmware."""
-env = { CARGO_BIN_NAME = "qemu_virt_dxe_core", "RUSTC_PROFILE" = "release", CARGO_BIN_TARGET = "aarch64-unknown-uefi", CARGO_BIN_FEATURES = "${BASE_FEATURES},aarch64", CARGO_TARGET_AARCH64_UNKNOWN_UEFI_RUSTFLAGS = "-C link-arg=/PDBALTPATH:qemu_virt_dxe_core.pdb" }
+env = { CARGO_BIN_NAME = "qemu_armvirt_dxe_core", "RUSTC_PROFILE" = "release", CARGO_BIN_TARGET = "aarch64-unknown-uefi", CARGO_BIN_FEATURES = "${BASE_FEATURES},aarch64", CARGO_TARGET_AARCH64_UNKNOWN_UEFI_RUSTFLAGS = "-C link-arg=/PDBALTPATH:qemu_armvirt_dxe_core.pdb" }
 run_task = "patch"
 
 [tasks.doc]

--- a/README.md
+++ b/README.md
@@ -67,15 +67,15 @@ binary in the [patina-qemu](https://github.com/OpenDevicePartnership/patina-qemu
 - VIRT (aarch64) debug
 
    ```shell
-   Compile Command:  'cargo make virt'
-   Output File:      'target/aarch64-unknown-uefi/debug/qemu_virt_dxe_core.efi'
+   Compile Command:  'cargo make armvirt'
+   Output File:      'target/aarch64-unknown-uefi/debug/qemu_armvirt_dxe_core.efi'
    ```
 
 - VIRT (aarch64) release
 
    ```shell
-   Compile Command:  'cargo make virt-release'
-   Output File:      'target/aarch64-unknown-uefi/release/qemu_virt_dxe_core.efi'
+   Compile Command:  'cargo make armvirt-release'
+   Output File:      'target/aarch64-unknown-uefi/release/qemu_armvirt_dxe_core.efi'
    ```
 
 The [patina_debugger](https://github.com/OpenDevicePartnership/patina/blob/main/docs/src/dxe_core/debugging.md) is

--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ binary in the [patina-qemu](https://github.com/OpenDevicePartnership/patina-qemu
    Output File:      'target/aarch64-unknown-uefi/release/qemu_sbsa_dxe_core.efi'
    ```
 
+- VIRT (aarch64) debug
+
+   ```shell
+   Compile Command:  'cargo make virt'
+   Output File:      'target/aarch64-unknown-uefi/debug/qemu_virt_dxe_core.efi'
+   ```
+
+- VIRT (aarch64) release
+
+   ```shell
+   Compile Command:  'cargo make virt-release'
+   Output File:      'target/aarch64-unknown-uefi/release/qemu_virt_dxe_core.efi'
+   ```
+
 The [patina_debugger](https://github.com/OpenDevicePartnership/patina/blob/main/docs/src/dxe_core/debugging.md) is
 built by default on debug builds, but not release builds. It can be built on release builds by passing the
 `build_debugger` feature to the build, e.g. `cargo make q35-release --features build_debugger`. The debugger

--- a/bin/arm_virt_dxe_core.rs
+++ b/bin/arm_virt_dxe_core.rs
@@ -1,4 +1,4 @@
-//! DXE Core Sample AARCH64 Binary for QEMU SBSA
+//! DXE Core Sample AARCH64 Binary for QEMU Arm Virt
 //!
 //! ## License
 //!
@@ -22,7 +22,7 @@ use patina_smbios;
 use patina_stacktrace::StackTrace;
 #[cfg(feature = "exit_on_patina_test_failure")]
 use qemu_exit::QEMUExit;
-use qemu_resources::sbsa::component::service as sbsa_services;
+use qemu_resources::armvirt::component::service as armvirt_services;
 extern crate alloc;
 
 #[panic_handler]
@@ -59,12 +59,12 @@ const _ENABLE_DEBUGGER: bool = false;
 static DEBUGGER: patina_debugger::PatinaDebugger<UartPl011> =
     patina_debugger::PatinaDebugger::new(UartPl011::new(0x0900_0000)).with_force_enable(_ENABLE_DEBUGGER);
 
-struct Sbsa;
+struct ArmVirt;
 
-// Default `MemoryInfo` implementation is sufficient for SBSA.
-impl MemoryInfo for Sbsa {}
+// Default `MemoryInfo` implementation is sufficient for Arm Virt.
+impl MemoryInfo for ArmVirt {}
 
-impl CpuInfo for Sbsa {
+impl CpuInfo for ArmVirt {
     fn gic_bases() -> GicBases {
         // SAFETY: gicd and gicr bases correctly point to the register spaces.
         // SAFETY: Access to these registers is exclusive to this struct instance.
@@ -72,11 +72,11 @@ impl CpuInfo for Sbsa {
     }
 }
 
-impl ComponentInfo for Sbsa {
+impl ComponentInfo for ArmVirt {
     fn components(mut add: Add<Component>) {
         add.component(AdvancedLoggerComponent::<UartPl011>::new(&LOGGER));
         add.component(patina_smbios::component::SmbiosProvider::new(3, 9));
-        add.component(sbsa_services::smbios_platform::SbsaSmbiosPlatform::new());
+        add.component(armvirt_services::smbios_platform::ArmVirtSmbiosPlatform::new());
         add.component(patina_test::component::TestRunner::default().with_callback(|test_name, err_msg| {
             log::error!("Test {} failed: {}", test_name, err_msg);
             #[cfg(feature = "exit_on_patina_test_failure")]
@@ -100,14 +100,14 @@ impl ComponentInfo for Sbsa {
     }
 }
 
-impl PlatformInfo for Sbsa {
+impl PlatformInfo for ArmVirt {
     type CpuInfo = Self;
     type MemoryInfo = Self;
     type ComponentInfo = Self;
     type Extractor = CompositeSectionExtractor;
 }
 
-static CORE: Core<Sbsa> = Core::new(CompositeSectionExtractor::new());
+static CORE: Core<ArmVirt> = Core::new(CompositeSectionExtractor::new());
 
 #[cfg_attr(target_os = "uefi", unsafe(export_name = "efi_main"))]
 pub extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {

--- a/bin/arm_virt_dxe_core.rs
+++ b/bin/arm_virt_dxe_core.rs
@@ -1,0 +1,126 @@
+//! DXE Core Sample AARCH64 Binary for QEMU SBSA
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+#![cfg(all(target_os = "uefi", feature = "aarch64"))]
+#![no_std]
+#![no_main]
+
+use core::{ffi::c_void, panic::PanicInfo};
+use patina::{log::Format, serial::uart::UartPl011};
+use patina_adv_logger::{
+    component::AdvancedLoggerComponent,
+    logger::{AdvancedLogger, TargetFilter},
+};
+use patina_dxe_core::*;
+use patina_ffs_extractors::CompositeSectionExtractor;
+use patina_smbios;
+use patina_stacktrace::StackTrace;
+#[cfg(feature = "exit_on_patina_test_failure")]
+use qemu_exit::QEMUExit;
+use qemu_resources::sbsa::component::service as sbsa_services;
+extern crate alloc;
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    log::error!("{}", info);
+
+    if let Err(err) = unsafe { StackTrace::dump() } {
+        log::error!("StackTrace: {}", err);
+    }
+
+    patina_debugger::breakpoint();
+
+    loop {}
+}
+
+static LOGGER: AdvancedLogger<UartPl011> = AdvancedLogger::new(
+    Format::Standard,
+    &[
+        TargetFilter { target: "goblin", log_level: log::LevelFilter::Off, hw_filter_override: None },
+        TargetFilter { target: "gcd_measure", log_level: log::LevelFilter::Off, hw_filter_override: None },
+        TargetFilter { target: "allocations", log_level: log::LevelFilter::Off, hw_filter_override: None },
+        TargetFilter { target: "efi_memory_map", log_level: log::LevelFilter::Off, hw_filter_override: None },
+    ],
+    log::LevelFilter::Info,
+    UartPl011::new(0x0900_0000),
+);
+
+#[cfg(feature = "enable_debugger")]
+const _ENABLE_DEBUGGER: bool = true;
+#[cfg(not(feature = "enable_debugger"))]
+const _ENABLE_DEBUGGER: bool = false;
+
+#[cfg(feature = "build_debugger")]
+static DEBUGGER: patina_debugger::PatinaDebugger<UartPl011> =
+    patina_debugger::PatinaDebugger::new(UartPl011::new(0x0900_0000)).with_force_enable(_ENABLE_DEBUGGER);
+
+struct Sbsa;
+
+// Default `MemoryInfo` implementation is sufficient for SBSA.
+impl MemoryInfo for Sbsa {}
+
+impl CpuInfo for Sbsa {
+    fn gic_bases() -> GicBases {
+        // SAFETY: gicd and gicr bases correctly point to the register spaces.
+        // SAFETY: Access to these registers is exclusive to this struct instance.
+        unsafe { GicBases::new(0x08000000, 0x080A0000) }
+    }
+}
+
+impl ComponentInfo for Sbsa {
+    fn components(mut add: Add<Component>) {
+        add.component(AdvancedLoggerComponent::<UartPl011>::new(&LOGGER));
+        add.component(patina_smbios::component::SmbiosProvider::new(3, 9));
+        add.component(sbsa_services::smbios_platform::SbsaSmbiosPlatform::new());
+        add.component(patina_test::component::TestRunner::default().with_callback(|test_name, err_msg| {
+            log::error!("Test {} failed: {}", test_name, err_msg);
+            #[cfg(feature = "exit_on_patina_test_failure")]
+            qemu_exit::AArch64::new().exit_failure();
+        }));
+        add.component(patina_performance::component::performance_config_provider::PerformanceConfigurationProvider);
+        add.component(patina_performance::component::performance::Performance);
+        add.component(patina_acpi::component::AcpiComponent::default());
+    }
+
+    fn configs(mut add: Add<Config>) {
+        add.config(patina_performance::config::PerfConfig {
+            enable_component: true,
+            enabled_measurements: {
+                patina::performance::Measurement::DriverBindingStart         // Adds driver binding start measurements.
+               | patina::performance::Measurement::DriverBindingStop        // Adds driver binding stop measurements.
+               | patina::performance::Measurement::LoadImage                // Adds load image measurements.
+               | patina::performance::Measurement::StartImage // Adds start image measurements.
+            },
+        })
+    }
+}
+
+impl PlatformInfo for Sbsa {
+    type CpuInfo = Self;
+    type MemoryInfo = Self;
+    type ComponentInfo = Self;
+    type Extractor = CompositeSectionExtractor;
+}
+
+static CORE: Core<Sbsa> = Core::new(CompositeSectionExtractor::new());
+
+#[cfg_attr(target_os = "uefi", unsafe(export_name = "efi_main"))]
+pub extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
+    log::set_logger(&LOGGER).map(|()| log::set_max_level(log::LevelFilter::Trace)).unwrap();
+    // SAFETY: The physical_hob_list pointer is considered valid at this point as it's provided by the core
+    // to the entry point.
+    unsafe {
+        LOGGER.init(physical_hob_list).unwrap();
+    }
+
+    #[cfg(feature = "build_debugger")]
+    patina_debugger::set_debugger(&DEBUGGER);
+
+    log::info!("DXE Core Platform Binary v{}", env!("CARGO_PKG_VERSION"));
+    CORE.entry_point(physical_hob_list)
+}

--- a/bin/arm_virt_dxe_core.rs
+++ b/bin/arm_virt_dxe_core.rs
@@ -47,7 +47,7 @@ static LOGGER: AdvancedLogger<UartPl011> = AdvancedLogger::new(
         TargetFilter { target: "efi_memory_map", log_level: log::LevelFilter::Off, hw_filter_override: None },
     ],
     log::LevelFilter::Info,
-    UartPl011::new(0x0900_0000),
+    UartPl011::new(PL011_UART_BASE),
 );
 
 #[cfg(feature = "enable_debugger")]
@@ -55,9 +55,18 @@ const _ENABLE_DEBUGGER: bool = true;
 #[cfg(not(feature = "enable_debugger"))]
 const _ENABLE_DEBUGGER: bool = false;
 
+/// Base address of the PL011 UART on the QEMU Arm Virt machine.
+const PL011_UART_BASE: usize = 0x0900_0000;
+
+/// Base address of the GIC distributor on the QEMU Arm Virt machine.
+const GICD_BASE: u64 = 0x0800_0000;
+
+/// Base address of the GIC redistributor on the QEMU Arm Virt machine.
+const GICR_BASE: u64 = 0x080A_0000;
+
 #[cfg(feature = "build_debugger")]
 static DEBUGGER: patina_debugger::PatinaDebugger<UartPl011> =
-    patina_debugger::PatinaDebugger::new(UartPl011::new(0x0900_0000)).with_force_enable(_ENABLE_DEBUGGER);
+    patina_debugger::PatinaDebugger::new(UartPl011::new(PL011_UART_BASE)).with_force_enable(_ENABLE_DEBUGGER);
 
 struct ArmVirt;
 
@@ -68,7 +77,7 @@ impl CpuInfo for ArmVirt {
     fn gic_bases() -> GicBases {
         // SAFETY: gicd and gicr bases correctly point to the register spaces.
         // SAFETY: Access to these registers is exclusive to this struct instance.
-        unsafe { GicBases::new(0x08000000, 0x080A0000) }
+        unsafe { GicBases::new(GICD_BASE, GICR_BASE) }
     }
 }
 

--- a/bin/arm_virt_dxe_core.rs
+++ b/bin/arm_virt_dxe_core.rs
@@ -18,7 +18,6 @@ use patina_adv_logger::{
 };
 use patina_dxe_core::*;
 use patina_ffs_extractors::CompositeSectionExtractor;
-use patina_smbios;
 use patina_stacktrace::StackTrace;
 #[cfg(feature = "exit_on_patina_test_failure")]
 use qemu_exit::QEMUExit;
@@ -119,7 +118,9 @@ impl PlatformInfo for ArmVirt {
 static CORE: Core<ArmVirt> = Core::new(CompositeSectionExtractor::new());
 
 #[cfg_attr(target_os = "uefi", unsafe(export_name = "efi_main"))]
-pub extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
+/// # Safety
+/// We must take on faith that the physical_hob_list pointer is valid.
+pub unsafe extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
     log::set_logger(&LOGGER).map(|()| log::set_max_level(log::LevelFilter::Trace)).unwrap();
     // SAFETY: The physical_hob_list pointer is considered valid at this point as it's provided by the core
     // to the entry point.

--- a/cspell.yml
+++ b/cspell.yml
@@ -58,6 +58,7 @@ words:
   - tiano
   - uart
   - uefi
+  - virt
   - vswhere
   - webpki
   - zbuild

--- a/cspell.yml
+++ b/cspell.yml
@@ -22,6 +22,7 @@ allowCompoundWords: true
 words:
   - acpi
   - apmc
+  - armvirt
   - asan
   - depex
   - dimm

--- a/src/armvirt.rs
+++ b/src/armvirt.rs
@@ -1,0 +1,11 @@
+//! QEMU Arm Virt Resources
+//!
+//! Resources used in the QEMU Arm Virt Patina binary.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+pub mod component;

--- a/src/armvirt/component.rs
+++ b/src/armvirt/component.rs
@@ -1,0 +1,11 @@
+//! QEMU Arm Virt Components
+//!
+//! Components used in the QEMU Arm Virt Patina binary.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+pub mod service;

--- a/src/armvirt/component/service.rs
+++ b/src/armvirt/component/service.rs
@@ -1,0 +1,14 @@
+//! QEMU Arm Virt Services
+//!
+//! Services used in the QEMU Arm Virt Patina binary.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+#[coverage(off)]
+pub mod smbios_platform;
+#[coverage(off)]
+pub mod smbios_test;

--- a/src/armvirt/component/service/smbios_platform.rs
+++ b/src/armvirt/component/service/smbios_platform.rs
@@ -1,0 +1,364 @@
+//! Arm Virt SMBIOS Platform Component
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+extern crate alloc;
+use alloc::{string::String, vec};
+
+use patina::{
+    component::{component, service::Service},
+    error::Result,
+};
+use patina_smbios::{
+    service::{SMBIOS_HANDLE_PI_RESERVED, Smbios, SmbiosExt, SmbiosTableHeader},
+    smbios_record::{
+        Type0PlatformFirmwareInformation, Type1SystemInformation, Type2BaseboardInformation, Type3SystemEnclosure,
+        Type4ProcessorInformation, Type7CacheInformation, Type16PhysicalMemoryArray, Type17MemoryDevice,
+        Type19MemoryArrayMappedAddress,
+    },
+};
+
+/// Arm Virt platform SMBIOS record provider.
+#[derive(Default)]
+pub struct ArmVirtSmbiosPlatform;
+
+#[component]
+impl ArmVirtSmbiosPlatform {
+    /// Creates a new instance.
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn entry_point(self, smbios: Service<dyn Smbios>) -> Result<()> {
+        log::debug!("=== Arm Virt SMBIOS Platform Component ===");
+
+        let (major, minor) = smbios.version();
+        log::trace!("SMBIOS Version: {}.{}", major, minor);
+
+        let bios_info = Type0PlatformFirmwareInformation {
+            header: SmbiosTableHeader::new(0, 0, SMBIOS_HANDLE_PI_RESERVED),
+            vendor: 1,
+            firmware_version: 2,
+            bios_starting_address_segment: 0xE800,
+            firmware_release_date: 3,
+            firmware_rom_size: 0xFF,
+            characteristics: 0x08,
+            characteristics_ext1: 0x03,
+            characteristics_ext2: 0x03,
+            system_bios_major_release: 1,
+            system_bios_minor_release: 0,
+            embedded_controller_major_release: 0xFF,
+            embedded_controller_minor_release: 0xFF,
+            extended_bios_rom_size: 0,
+            string_pool: vec![
+                String::from("Patina Firmware"),
+                String::from(env!("CARGO_PKG_VERSION")),
+                String::from(option_env!("BUILD_DATE").unwrap_or("01/01/1970")),
+            ],
+        };
+
+        // Type 0 and Type 1 are required per SMBIOS spec Section 6.2. Propagate errors
+        // to avoid publishing an incompliant table.
+        let type0_handle = smbios.add_record(None, &bios_info).map_err(|e| {
+            log::error!("Failed to add required Type 0 (BIOS Info): {:?}", e);
+            e
+        })?;
+        log::trace!("  Type 0 (BIOS Info) - Handle 0x{:04X}", type0_handle);
+
+        let system_info = Type1SystemInformation {
+            header: SmbiosTableHeader::new(1, 0, SMBIOS_HANDLE_PI_RESERVED),
+            manufacturer: 1,
+            product_name: 2,
+            version: 3,
+            serial_number: 4,
+            uuid: [0; 16],
+            wake_up_type: 0x06,
+            sku_number: 5,
+            family: 6,
+            string_pool: vec![
+                String::from("QEMU"),
+                String::from("Arm Virtual Machine"),
+                String::from("1.0"),
+                String::from("VM-001"),
+                String::from("ARMVIRT-STANDARD"),
+                String::from("Virtual Machine Family"),
+            ],
+        };
+
+        let type1_handle = smbios.add_record(None, &system_info).map_err(|e| {
+            log::error!("Failed to add required Type 1 (System Info): {:?}", e);
+            e
+        })?;
+        log::trace!("  Type 1 (System Info) - Handle 0x{:04X}", type1_handle);
+
+        let enclosure_info = Type3SystemEnclosure {
+            header: SmbiosTableHeader::new(3, 0, SMBIOS_HANDLE_PI_RESERVED),
+            manufacturer: 1,
+            enclosure_type: 0x03,
+            version: 2,
+            serial_number: 3,
+            asset_tag_number: 4,
+            bootup_state: 0x03,
+            power_supply_state: 0x03,
+            thermal_state: 0x03,
+            security_status: 0x02,
+            oem_defined: 0x00000000,
+            height: 0x00,
+            number_of_power_cords: 0x01,
+            contained_element_count: 0x00,
+            contained_element_record_length: 0x00,
+            string_pool: vec![
+                String::from("Example Corporation"),
+                String::from("Example Chassis v1.0"),
+                String::from("CHASSIS-99999"),
+                String::from("ASSET-CHASSIS-001"),
+            ],
+        };
+
+        let mut type3_handle = 0xFFFF;
+        match smbios.add_record(None, &enclosure_info) {
+            Ok(handle) => {
+                log::trace!("  Type 3 (System Enclosure) - Handle 0x{:04X}", handle);
+                type3_handle = handle;
+            }
+            Err(e) => log::warn!("  Failed to add Type 3: {:?}", e),
+        }
+
+        let baseboard_info = Type2BaseboardInformation {
+            header: SmbiosTableHeader::new(2, 0, SMBIOS_HANDLE_PI_RESERVED),
+            manufacturer: 1,
+            product: 2,
+            version: 3,
+            serial_number: 4,
+            asset_tag: 5,
+            feature_flags: 0x01,
+            location_in_chassis: 6,
+            chassis_handle: type3_handle,
+            board_type: 0x0A,
+            contained_object_handles: 0,
+            string_pool: vec![
+                String::from("Example Corporation"),
+                String::from("Example Baseboard"),
+                String::from("1.0"),
+                String::from("MB-67890"),
+                String::from("ASSET-MB-001"),
+                String::from("Main Board Slot"),
+            ],
+        };
+
+        match smbios.add_record(None, &baseboard_info) {
+            Ok(handle) => log::trace!("  Type 2 (Base Board Info) - Handle 0x{:04X}", handle),
+            Err(e) => log::warn!("  Failed to add Type 2: {:?}", e),
+        }
+
+        // Type 7: Cache Information - L1 and L2 caches for the virtual processor
+        let l1_cache = Type7CacheInformation {
+            header: SmbiosTableHeader::new(7, 0, SMBIOS_HANDLE_PI_RESERVED),
+            socket_designation: 1,
+            cache_configuration: 0x0180, // L1, enabled, write-back
+            maximum_cache_size: 64,      // 64 KB
+            installed_size: 64,
+            supported_sram_type: 0x0002, // Unknown
+            current_sram_type: 0x0002,
+            cache_speed: 0,
+            error_correction_type: 0x05, // Single-bit ECC
+            system_cache_type: 0x05,     // Unified
+            associativity: 0x06,         // 8-way
+            maximum_cache_size2: 64,
+            installed_cache_size2: 64,
+            string_pool: vec![String::from("L1 Cache")],
+        };
+
+        let mut l1_cache_handle = 0xFFFF;
+        match smbios.add_record(None, &l1_cache) {
+            Ok(handle) => {
+                log::trace!("  Type 7 (L1 Cache) - Handle 0x{:04X}", handle);
+                l1_cache_handle = handle;
+            }
+            Err(e) => log::warn!("  Failed to add Type 7 (L1 Cache): {:?}", e),
+        }
+
+        let l2_cache = Type7CacheInformation {
+            header: SmbiosTableHeader::new(7, 0, SMBIOS_HANDLE_PI_RESERVED),
+            socket_designation: 1,
+            cache_configuration: 0x0181, // L2, enabled, write-back
+            maximum_cache_size: 256,     // 256 KB
+            installed_size: 256,
+            supported_sram_type: 0x0002,
+            current_sram_type: 0x0002,
+            cache_speed: 0,
+            error_correction_type: 0x05, // Single-bit ECC
+            system_cache_type: 0x05,     // Unified
+            associativity: 0x06,         // 8-way
+            maximum_cache_size2: 256,
+            installed_cache_size2: 256,
+            string_pool: vec![String::from("L2 Cache")],
+        };
+
+        let mut l2_cache_handle = 0xFFFF;
+        match smbios.add_record(None, &l2_cache) {
+            Ok(handle) => {
+                log::trace!("  Type 7 (L2 Cache) - Handle 0x{:04X}", handle);
+                l2_cache_handle = handle;
+            }
+            Err(e) => log::warn!("  Failed to add Type 7 (L2 Cache): {:?}", e),
+        }
+
+        // Type 4: Processor Information
+        let processor_info = Type4ProcessorInformation {
+            header: SmbiosTableHeader::new(4, 0, SMBIOS_HANDLE_PI_RESERVED),
+            socket_designation: 1,
+            processor_type: 0x03,   // Central Processor
+            processor_family: 0xFE, // Use processor_family2
+            processor_manufacturer: 2,
+            processor_id: [0u8; 8],
+            processor_version: 3,
+            voltage: 0x80,     // Legacy mode, voltage unknown
+            external_clock: 0, // Unknown
+            max_speed: 2000,
+            current_speed: 2000,
+            status: 0x41,            // CPU Enabled, Populated
+            processor_upgrade: 0x06, // None
+            l1_cache_handle,
+            l2_cache_handle,
+            l3_cache_handle: 0xFFFF, // Not provided
+            serial_number: 4,
+            asset_tag: 5,
+            part_number: 6,
+            core_count: 1,
+            core_enabled: 1,
+            thread_count: 1,
+            processor_characteristics: 0x04, // 64-bit capable
+            processor_family2: 0x0100,       // ARMv8
+            core_count2: 1,
+            core_enabled2: 1,
+            thread_count2: 1,
+            string_pool: vec![
+                String::from("CPU0"),
+                String::from("QEMU"),
+                String::from("ARMv8 Virtual Processor"),
+                String::from("SN-CPU-001"),
+                String::from("ASSET-CPU-001"),
+                String::from("PN-CPU-001"),
+            ],
+        };
+
+        match smbios.add_record(None, &processor_info) {
+            Ok(handle) => log::trace!("  Type 4 (Processor Info) - Handle 0x{:04X}", handle),
+            Err(e) => log::warn!("  Failed to add Type 4: {:?}", e),
+        }
+
+        // Type 16: Physical Memory Array
+        let memory_array = Type16PhysicalMemoryArray {
+            header: SmbiosTableHeader::new(16, 0, SMBIOS_HANDLE_PI_RESERVED),
+            location: 0x03,                          // System board
+            use_field: 0x03,                         // System memory
+            memory_error_correction: 0x03,           // None
+            maximum_capacity: 0x00100000,            // 1 GB in KB
+            memory_error_information_handle: 0xFFFE, // Not provided
+            number_of_memory_devices: 1,
+            extended_maximum_capacity: 0,
+            string_pool: vec![],
+        };
+
+        let mut type16_handle = 0xFFFF;
+        match smbios.add_record(None, &memory_array) {
+            Ok(handle) => {
+                log::trace!("  Type 16 (Physical Memory Array) - Handle 0x{:04X}", handle);
+                type16_handle = handle;
+            }
+            Err(e) => log::warn!("  Failed to add Type 16: {:?}", e),
+        }
+
+        // Type 17: Memory Device
+        let memory_device = Type17MemoryDevice {
+            header: SmbiosTableHeader::new(17, 0, SMBIOS_HANDLE_PI_RESERVED),
+            physical_memory_array_handle: type16_handle,
+            memory_error_information_handle: 0xFFFE, // Not provided
+            total_width: 64,
+            data_width: 64,
+            size: 0x0400,      // 1024 MB
+            form_factor: 0x09, // DIMM
+            device_set: 0,
+            device_locator: 1,
+            bank_locator: 2,
+            memory_type: 0x1A,   // DDR4
+            type_detail: 0x0080, // Synchronous
+            speed: 3200,
+            manufacturer: 3,
+            serial_number: 4,
+            asset_tag: 5,
+            part_number: 6,
+            attributes: 0x01, // Single rank
+            extended_size: 0,
+            configured_memory_clock_speed: 3200,
+            minimum_voltage: 1200,
+            maximum_voltage: 1200,
+            configured_voltage: 1200,
+            memory_technology: 0x02,                  // DRAM
+            memory_operating_mode_capability: 0x0004, // Volatile
+            firmware_version: 7,
+            module_manufacturer_id: 0,
+            module_product_id: 0,
+            memory_subsystem_controller_manufacturer_id: 0,
+            memory_subsystem_controller_product_id: 0,
+            non_volatile_size: 0,
+            volatile_size: 0x40000000, // 1 GB
+            cache_size: 0,
+            logical_size: 0,
+            extended_speed: 0,
+            extended_configured_memory_speed: 0,
+            pmic0_manufacturer_id: 0,
+            pmic0_revision_number: 0,
+            rcd_manufacturer_id: 0,
+            rcd_revision_number: 0,
+            string_pool: vec![
+                String::from("DIMM 0"),
+                String::from("BANK 0"),
+                String::from("QEMU"),
+                String::from("SN-DIMM-001"),
+                String::from("ASSET-DIMM-001"),
+                String::from("QEMU-DIMM"),
+                String::from("v1.0"),
+            ],
+        };
+
+        match smbios.add_record(None, &memory_device) {
+            Ok(handle) => log::trace!("  Type 17 (Memory Device) - Handle 0x{:04X}", handle),
+            Err(e) => log::warn!("  Failed to add Type 17: {:?}", e),
+        }
+
+        // Type 19: Memory Array Mapped Address
+        let memory_mapped = Type19MemoryArrayMappedAddress {
+            header: SmbiosTableHeader::new(19, 0, SMBIOS_HANDLE_PI_RESERVED),
+            starting_address: 0,
+            ending_address: 0x000FFFFF, // 1 GB - 1 in KB
+            memory_array_handle: type16_handle,
+            partition_width: 1,
+            extended_starting_address: 0,
+            extended_ending_address: 0,
+            string_pool: vec![],
+        };
+
+        match smbios.add_record(None, &memory_mapped) {
+            Ok(handle) => log::trace!("  Type 19 (Memory Array Mapped Address) - Handle 0x{:04X}", handle),
+            Err(e) => log::warn!("  Failed to add Type 19: {:?}", e),
+        }
+
+        log::debug!("Publishing SMBIOS table...");
+        let (table_addr, entry_point_addr) = smbios.publish_table().map_err(|e| {
+            log::error!("Failed to publish SMBIOS table: {:?}", e);
+            e
+        })?;
+        log::debug!("SMBIOS table published successfully");
+        log::debug!("  Entry Point: 0x{:X}", entry_point_addr);
+        log::debug!("  Table Data: 0x{:X}", table_addr);
+
+        Ok(())
+    }
+}

--- a/src/armvirt/component/service/smbios_platform.rs
+++ b/src/armvirt/component/service/smbios_platform.rs
@@ -266,7 +266,7 @@ impl ArmVirtSmbiosPlatform {
             string_pool: vec![],
         };
 
-        let mut type16_handle = 0xFFFF;
+        let mut type16_handle = 0xFFFE;
         match smbios.add_record(None, &memory_array) {
             Ok(handle) => {
                 log::trace!("  Type 16 (Physical Memory Array) - Handle 0x{:04X}", handle);

--- a/src/armvirt/component/service/smbios_platform.rs
+++ b/src/armvirt/component/service/smbios_platform.rs
@@ -234,7 +234,7 @@ impl ArmVirtSmbiosPlatform {
             core_enabled: 1,
             thread_count: 1,
             processor_characteristics: 0x04, // 64-bit capable
-            processor_family2: 0x0100,       // ARMv8
+            processor_family2: 0x0101,       // ARMv8
             core_count2: 1,
             core_enabled2: 1,
             thread_count2: 1,

--- a/src/armvirt/component/service/smbios_platform.rs
+++ b/src/armvirt/component/service/smbios_platform.rs
@@ -266,88 +266,94 @@ impl ArmVirtSmbiosPlatform {
             string_pool: vec![],
         };
 
-        let mut type16_handle = 0xFFFE;
-        match smbios.add_record(None, &memory_array) {
+        let type16_handle = match smbios.add_record(None, &memory_array) {
             Ok(handle) => {
                 log::trace!("  Type 16 (Physical Memory Array) - Handle 0x{:04X}", handle);
-                type16_handle = handle;
+                Some(handle)
             }
-            Err(e) => log::warn!("  Failed to add Type 16: {:?}", e),
-        }
-
-        // Type 17: Memory Device
-        let memory_device = Type17MemoryDevice {
-            header: SmbiosTableHeader::new(17, 0, SMBIOS_HANDLE_PI_RESERVED),
-            physical_memory_array_handle: type16_handle,
-            memory_error_information_handle: 0xFFFE, // Not provided
-            total_width: 64,
-            data_width: 64,
-            size: 0x0400,      // 1024 MB
-            form_factor: 0x09, // DIMM
-            device_set: 0,
-            device_locator: 1,
-            bank_locator: 2,
-            memory_type: 0x1A,   // DDR4
-            type_detail: 0x0080, // Synchronous
-            speed: 3200,
-            manufacturer: 3,
-            serial_number: 4,
-            asset_tag: 5,
-            part_number: 6,
-            attributes: 0x01, // Single rank
-            extended_size: 0,
-            configured_memory_clock_speed: 3200,
-            minimum_voltage: 1200,
-            maximum_voltage: 1200,
-            configured_voltage: 1200,
-            memory_technology: 0x02,                  // DRAM
-            memory_operating_mode_capability: 0x0004, // Volatile
-            firmware_version: 7,
-            module_manufacturer_id: 0,
-            module_product_id: 0,
-            memory_subsystem_controller_manufacturer_id: 0,
-            memory_subsystem_controller_product_id: 0,
-            non_volatile_size: 0,
-            volatile_size: 0x40000000, // 1 GB
-            cache_size: 0,
-            logical_size: 0,
-            extended_speed: 0,
-            extended_configured_memory_speed: 0,
-            pmic0_manufacturer_id: 0,
-            pmic0_revision_number: 0,
-            rcd_manufacturer_id: 0,
-            rcd_revision_number: 0,
-            string_pool: vec![
-                String::from("DIMM 0"),
-                String::from("BANK 0"),
-                String::from("QEMU"),
-                String::from("SN-DIMM-001"),
-                String::from("ASSET-DIMM-001"),
-                String::from("QEMU-DIMM"),
-                String::from("v1.0"),
-            ],
+            Err(e) => {
+                log::warn!("  Failed to add Type 16: {:?}", e);
+                None
+            }
         };
 
-        match smbios.add_record(None, &memory_device) {
-            Ok(handle) => log::trace!("  Type 17 (Memory Device) - Handle 0x{:04X}", handle),
-            Err(e) => log::warn!("  Failed to add Type 17: {:?}", e),
-        }
+        if let Some(type16_handle) = type16_handle {
+            // Type 17: Memory Device
+            let memory_device = Type17MemoryDevice {
+                header: SmbiosTableHeader::new(17, 0, SMBIOS_HANDLE_PI_RESERVED),
+                physical_memory_array_handle: type16_handle,
+                memory_error_information_handle: 0xFFFE, // Not provided
+                total_width: 64,
+                data_width: 64,
+                size: 0x0400,      // 1024 MB
+                form_factor: 0x09, // DIMM
+                device_set: 0,
+                device_locator: 1,
+                bank_locator: 2,
+                memory_type: 0x1A,   // DDR4
+                type_detail: 0x0080, // Synchronous
+                speed: 3200,
+                manufacturer: 3,
+                serial_number: 4,
+                asset_tag: 5,
+                part_number: 6,
+                attributes: 0x01, // Single rank
+                extended_size: 0,
+                configured_memory_clock_speed: 3200,
+                minimum_voltage: 1200,
+                maximum_voltage: 1200,
+                configured_voltage: 1200,
+                memory_technology: 0x02,                  // DRAM
+                memory_operating_mode_capability: 0x0004, // Volatile
+                firmware_version: 7,
+                module_manufacturer_id: 0,
+                module_product_id: 0,
+                memory_subsystem_controller_manufacturer_id: 0,
+                memory_subsystem_controller_product_id: 0,
+                non_volatile_size: 0,
+                volatile_size: 0x40000000, // 1 GB
+                cache_size: 0,
+                logical_size: 0,
+                extended_speed: 0,
+                extended_configured_memory_speed: 0,
+                pmic0_manufacturer_id: 0,
+                pmic0_revision_number: 0,
+                rcd_manufacturer_id: 0,
+                rcd_revision_number: 0,
+                string_pool: vec![
+                    String::from("DIMM 0"),
+                    String::from("BANK 0"),
+                    String::from("QEMU"),
+                    String::from("SN-DIMM-001"),
+                    String::from("ASSET-DIMM-001"),
+                    String::from("QEMU-DIMM"),
+                    String::from("v1.0"),
+                ],
+            };
 
-        // Type 19: Memory Array Mapped Address
-        let memory_mapped = Type19MemoryArrayMappedAddress {
-            header: SmbiosTableHeader::new(19, 0, SMBIOS_HANDLE_PI_RESERVED),
-            starting_address: 0,
-            ending_address: 0x000FFFFF, // 1 GB - 1 in KB
-            memory_array_handle: type16_handle,
-            partition_width: 1,
-            extended_starting_address: 0,
-            extended_ending_address: 0,
-            string_pool: vec![],
-        };
+            match smbios.add_record(None, &memory_device) {
+                Ok(handle) => log::trace!("  Type 17 (Memory Device) - Handle 0x{:04X}", handle),
+                Err(e) => log::warn!("  Failed to add Type 17: {:?}", e),
+            }
 
-        match smbios.add_record(None, &memory_mapped) {
-            Ok(handle) => log::trace!("  Type 19 (Memory Array Mapped Address) - Handle 0x{:04X}", handle),
-            Err(e) => log::warn!("  Failed to add Type 19: {:?}", e),
+            // Type 19: Memory Array Mapped Address
+            let memory_mapped = Type19MemoryArrayMappedAddress {
+                header: SmbiosTableHeader::new(19, 0, SMBIOS_HANDLE_PI_RESERVED),
+                starting_address: 0,
+                ending_address: 0x000FFFFF, // 1 GB - 1 in KB
+                memory_array_handle: type16_handle,
+                partition_width: 1,
+                extended_starting_address: 0,
+                extended_ending_address: 0,
+                string_pool: vec![],
+            };
+
+            match smbios.add_record(None, &memory_mapped) {
+                Ok(handle) => log::trace!("  Type 19 (Memory Array Mapped Address) - Handle 0x{:04X}", handle),
+                Err(e) => log::warn!("  Failed to add Type 19: {:?}", e),
+            }
+        } else {
+            log::warn!("  Skipping Type 17 and Type 19 because Type 16 was not added");
         }
 
         log::debug!("Publishing SMBIOS table...");

--- a/src/armvirt/component/service/smbios_test.rs
+++ b/src/armvirt/component/service/smbios_test.rs
@@ -1,0 +1,186 @@
+//! QEMU Arm Virt SMBIOS Test
+//!
+//! Verifies that SMBIOS interfaces are working as expected on the QEMU Arm Virt platform
+//! by exercising the EDK2-compatible C protocol FFI layer.
+//!
+//! ## License
+//!
+//! Copyright (c) Microsoft Corporation.
+//!
+//! SPDX-License-Identifier: Apache-2.0
+//!
+
+extern crate alloc;
+use alloc::{ffi::CString, vec, vec::Vec};
+use core::ffi::c_char;
+
+use patina::boot_services::{BootServices, StandardBootServices};
+use patina_smbios::service::{SMBIOS_HANDLE_PI_RESERVED, SmbiosHandle, SmbiosTableHeader};
+use patina_test::{patina_test, u_assert, u_assert_eq, u_assert_ne};
+use r_efi::efi;
+
+/// Tests the SMBIOS C Protocol FFI layer by calling the protocol functions directly.
+/// This exercises the EDK2-compatible protocol layer (Add, UpdateString, Remove, GetNext)
+/// which are the FFI functions that C code calls.
+#[patina_test]
+fn armvirt_smbios_ffi_test(boot_services: StandardBootServices) -> patina_test::error::Result {
+    log::debug!("SMBIOS FFI Test - Testing C Protocol FFI Layer");
+
+    test_c_protocol_layer(&boot_services)?;
+
+    log::debug!("SMBIOS FFI Test complete");
+    Ok(())
+}
+
+/// Test the C Protocol FFI layer by calling the protocol functions directly
+fn test_c_protocol_layer(boot_services: &StandardBootServices) -> patina_test::error::Result {
+    log::trace!("Testing SMBIOS C Protocol functions...");
+
+    // Define the SMBIOS protocol GUID
+    const SMBIOS_PROTOCOL_GUID: efi::Guid =
+        efi::Guid::from_fields(0x03583ff6, 0xcb36, 0x4940, 0x94, 0x7e, &[0xb9, 0xb3, 0x9f, 0x4a, 0xfa, 0xf7]);
+
+    // Locate the SMBIOS protocol
+    let protocol_ptr = unsafe {
+        boot_services.locate_protocol_unchecked(&SMBIOS_PROTOCOL_GUID, core::ptr::null_mut()).map_err(|e| {
+            log::error!("Failed to locate SMBIOS protocol: {:?}", e);
+            "Failed to locate SMBIOS protocol"
+        })?
+    };
+
+    // Cast to protocol structure
+    // SAFETY: We know this is the correct protocol structure because we just located it
+    #[repr(C)]
+    struct SmbiosProtocol {
+        add: extern "efiapi" fn(
+            *const SmbiosProtocol,
+            efi::Handle,
+            *mut SmbiosHandle,
+            *const SmbiosTableHeader,
+        ) -> efi::Status,
+        update_string:
+            extern "efiapi" fn(*const SmbiosProtocol, *mut SmbiosHandle, *mut usize, *const c_char) -> efi::Status,
+        remove: extern "efiapi" fn(*const SmbiosProtocol, SmbiosHandle) -> efi::Status,
+        get_next: extern "efiapi" fn(
+            *const SmbiosProtocol,
+            *mut SmbiosHandle,
+            *mut u8,
+            *mut *mut SmbiosTableHeader,
+            *mut efi::Handle,
+        ) -> efi::Status,
+        major_version: u8,
+        minor_version: u8,
+    }
+
+    let protocol = unsafe { &*(protocol_ptr as *const SmbiosProtocol) };
+
+    // Test 1: Add a record using the C protocol Add function
+    log::trace!("  Test 1: Protocol Add function...");
+    let test_record = create_test_type2_record();
+    let mut handle: SmbiosHandle = 0;
+
+    let status = (protocol.add)(
+        protocol,
+        core::ptr::null_mut(), // producer_handle
+        &mut handle,
+        test_record.as_ptr() as *const SmbiosTableHeader,
+    );
+    u_assert_eq!(status, efi::Status::SUCCESS, "Protocol Add should succeed");
+    log::trace!("    [PASS] Protocol Add succeeded - Handle: 0x{:04X}", handle);
+
+    // Test 2: UpdateString using the C protocol UpdateString function
+    log::trace!("  Test 2: Protocol UpdateString function...");
+    let new_string = CString::new("Updated via C Protocol").unwrap();
+    let mut string_number: usize = 1;
+
+    let status = (protocol.update_string)(protocol, &mut handle, &mut string_number, new_string.as_ptr());
+    u_assert_eq!(status, efi::Status::SUCCESS, "Protocol UpdateString should succeed");
+    log::trace!("    [PASS] Protocol UpdateString succeeded");
+
+    // Test 3: Remove using the C protocol Remove function
+    log::trace!("  Test 3: Protocol Remove function...");
+    let status = (protocol.remove)(protocol, handle);
+    u_assert_eq!(status, efi::Status::SUCCESS, "Protocol Remove should succeed");
+    log::trace!("    [PASS] Protocol Remove succeeded");
+
+    // Test 4: Verify removal - UpdateString should now fail
+    log::trace!("  Test 4: Verify record removed...");
+    let status = (protocol.update_string)(protocol, &mut handle, &mut string_number, new_string.as_ptr());
+    u_assert_ne!(status, efi::Status::SUCCESS, "UpdateString after removal should fail");
+    log::trace!("    [PASS] UpdateString after removal correctly failed: {:?}", status);
+
+    // Test 5: GetNext - enumerate records
+    log::trace!("  Test 5: Protocol GetNext function...");
+    let mut iter_handle: SmbiosHandle = SMBIOS_HANDLE_PI_RESERVED;
+    let mut record_type: u8 = 0;
+    let mut record_ptr: *mut SmbiosTableHeader = core::ptr::null_mut();
+    let mut producer_handle: efi::Handle = core::ptr::null_mut();
+
+    // Get first record
+    let status =
+        (protocol.get_next)(protocol, &mut iter_handle, &mut record_type, &mut record_ptr, &mut producer_handle);
+    u_assert_eq!(status, efi::Status::SUCCESS, "Protocol GetNext (first) should succeed");
+
+    // Copy fields from packed struct to avoid unaligned reference
+    let (rec_type, rec_handle, rec_length) = unsafe {
+        let header = &*record_ptr;
+        (header.record_type, header.handle, header.length)
+    };
+    u_assert!(!record_ptr.is_null(), "Record pointer should not be null");
+    log::trace!(
+        "    [PASS] Protocol GetNext (first) succeeded - Type: {}, Handle: 0x{:04X}, Length: {}",
+        rec_type,
+        rec_handle,
+        rec_length
+    );
+
+    // Get next record (optional - may not exist if only a few records in table)
+    let status =
+        (protocol.get_next)(protocol, &mut iter_handle, &mut record_type, &mut record_ptr, &mut producer_handle);
+
+    if status == efi::Status::SUCCESS {
+        // Copy fields from packed struct to avoid unaligned reference
+        let (rec_type, rec_handle, rec_length) = unsafe {
+            let header = &*record_ptr;
+            (header.record_type, header.handle, header.length)
+        };
+        log::trace!(
+            "    [PASS] Protocol GetNext (second) succeeded - Type: {}, Handle: 0x{:04X}, Length: {}",
+            rec_type,
+            rec_handle,
+            rec_length
+        );
+    } else {
+        log::trace!("    [INFO] Protocol GetNext (second) returned: {:?} (no more records)", status);
+    }
+
+    log::trace!("C Protocol FFI layer testing complete");
+    Ok(())
+}
+
+/// Creates a Type 2 (Baseboard Information) record as raw bytes
+fn create_test_type2_record() -> Vec<u8> {
+    let mut record = vec![];
+
+    // Header: type=2, length=0x08, handle=auto-assign
+    record.push(2); // type
+    record.push(0x08); // length (8 bytes total for Type 2 minimum)
+    record.extend_from_slice(&SMBIOS_HANDLE_PI_RESERVED.to_le_bytes());
+
+    // Type 2 fixed data (4 bytes after header to reach length of 8)
+    record.push(1); // manufacturer (string 1)
+    record.push(2); // product (string 2)
+    record.push(3); // version (string 3)
+    record.push(4); // serial number (string 4)
+
+    // String pool
+    record.extend_from_slice(b"Test Manufacturer\0");
+    record.extend_from_slice(b"Test Product\0");
+    record.extend_from_slice(b"1.0\0");
+    record.extend_from_slice(b"SN-12345\0");
+
+    // String pool terminator (double null)
+    record.push(0);
+
+    record
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,4 +15,5 @@
 pub mod q35;
 #[cfg(any(feature = "aarch64", test))]
 pub mod sbsa;
+#[cfg(any(feature = "aarch64", test))]
 pub mod armvirt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,3 +15,4 @@
 pub mod q35;
 #[cfg(any(feature = "aarch64", test))]
 pub mod sbsa;
+pub mod armvirt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,9 @@
 #![no_std]
 #![feature(coverage_attribute)]
 
+#[cfg(any(feature = "aarch64", test))]
+pub mod armvirt;
 #[cfg(any(feature = "x64", test))]
 pub mod q35;
 #[cfg(any(feature = "aarch64", test))]
 pub mod sbsa;
-#[cfg(any(feature = "aarch64", test))]
-pub mod armvirt;


### PR DESCRIPTION
## Description

This change adds a arm-virt based QEMU platform for better supported TFA, hafnium and TPM usage.

It currently only adds the new core implementation in parallel to the SBSA core. But the plan is to remove the SBSA once the downstream is updated. This _combability mode_ ensures smoother transitioning without impacting downstream validations.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

This was tested on QEMU v11 and booted to Windows desktop.

## Integration Instructions

See updated readme in PR.
