### PR TITLE
v3.0.7: Update to patina v21.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,9 +351,9 @@ checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "patina"
-version = "21.1.0"
+version = "21.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c291bf41d3f5fee02c8b6f165b46af97e9cead5483c06bc55bffd55bd01339c3"
+checksum = "bec23b00420d750e81d236a5e0f44d4b3bc6da36b4f7196a9e12cf5acf968ebd"
 dependencies = [
  "cfg-if",
  "compile-time",
@@ -378,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "patina_acpi"
-version = "21.1.0"
+version = "21.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f08948e443a5ab4c08477891a2387c7ff3e83aeaa992e62c2a33c2e4db8bec9e"
+checksum = "58c7297f34a614e2f306400fdea36a3649f30b8cc528170d244ce09db60380aa"
 dependencies = [
  "log",
  "memoffset",
@@ -395,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "patina_adv_logger"
-version = "21.1.0"
+version = "21.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b79595a1e883390e67d65fc4c98fdd3ea439b446cb862f7d2680883110b2d76"
+checksum = "389bc04315d0f70f926c6264eb9437acc1cfd134c8c3cb58155d3dc1a33a9d60"
 dependencies = [
  "log",
  "mu_rust_helpers",
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "patina_debugger"
-version = "21.1.0"
+version = "21.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6486c80bf0e17febf905d4eea1fe2c35a140de1ac50bedf77b16a28d218ee9d6"
+checksum = "c440f681186cec8f89b7b38f3acc375c5589a77fad76e89a93ba9d3b328d631c"
 dependencies = [
  "bitfield-struct",
  "cfg-if",
@@ -428,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "patina_dxe_core"
-version = "21.1.0"
+version = "21.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "860ae221d2851f3485b49d91343a961b5ca50fafd6d4933acc1714c8a3f5c84a"
+checksum = "e442086b63d05ddf95a02e3a87b9fed802910eb55e5c8a2aa5af78c24a1777a6"
 dependencies = [
  "arm-gic",
  "bitfield-struct",
@@ -459,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs"
-version = "21.1.0"
+version = "21.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadd13f6ea63692c86368127ec7591f57811499db03b6d8a06a63721e6b87c5a"
+checksum = "c9213b7a2f702b569762a29538b252e1f7209adf4de6a7899fc32a441635e441"
 dependencies = [
  "log",
  "patina",
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs_extractors"
-version = "21.1.0"
+version = "21.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22be533812c01e812894e88d20b512a0f5a98159c569c09987ddbf30949dca3"
+checksum = "e03d7c79f79291604bb489b2360a7fa1deff3342b05ffe21bb2b8c9d0a8c7715"
 dependencies = [
  "alloc-no-stdlib",
  "brotli-decompressor",
@@ -486,18 +486,18 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_collections"
-version = "21.1.0"
+version = "21.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0b88c2ed602b67fe3ffab2b98b20aa6dd6abe3e618b407c1d052ef6a74352a"
+checksum = "4ff33fa3f8b3c6687160c43bc3c4d81ad9919b99ebc2052fa810c1f75a70f069"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "patina_internal_cpu"
-version = "21.1.0"
+version = "21.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3845febc743dbdca42cf82ab0a7623f29a1041cb8c17927a8296f50310781"
+checksum = "8161983fca545715373f1c14e3cb21f469e156e1415fcccf615b86a131f1b612"
 dependencies = [
  "arm-gic",
  "cfg-if",
@@ -513,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_depex"
-version = "21.1.0"
+version = "21.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a911caa2f82809ead4fb2e90ac855c9631cb7002d542d29471a542bc0e4d867d"
+checksum = "abe860f312315bf1ed0abe4157613552169aa08f4dbe14b4609631b75fcea488"
 dependencies = [
  "log",
  "r-efi",
@@ -534,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "patina_macro"
-version = "21.1.0"
+version = "21.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c52d4975be31d31a99a67f7c71572527a3314874cc124cd4cb2fd2c33b2cbaa"
+checksum = "10feb0e24c831f028f4de2e86b1b592ec0dfb432c3e4d44bd47f4b55aef98fa4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -546,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "patina_mm"
-version = "21.1.0"
+version = "21.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3057e8cda36c7f2929f638b2cd74e00c3f20feba54bbc9bc6d6d3907bfdc2998"
+checksum = "3a4002faad67ab194c3d3af8d7c127c3c8ba341580bff0024d46396fcaf0d409"
 dependencies = [
  "cfg-if",
  "log",
@@ -582,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "patina_performance"
-version = "21.1.0"
+version = "21.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c70dc44ebbc2477e53799c7147892ce1a2c1fd87b04c3feec1c18b194334d6"
+checksum = "44c4d3d2d08ad89ef98ea69dcd16c319fbfe8c2334b2911558b67c4ddc2ed53c"
 dependencies = [
  "log",
  "mu_rust_helpers",
@@ -598,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "patina_samples"
-version = "21.1.0"
+version = "21.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c266ab0f6d03c8938017e9815efa6131241f9d97403e240a1bb7576e6ae78349"
+checksum = "59ad10a4e2ed5336c5ddb1d5d202c80cb3ac6653c13e07966c93f35979afa0c0"
 dependencies = [
  "log",
  "patina",
@@ -610,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "patina_smbios"
-version = "21.1.0"
+version = "21.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "962f441e7cc493096d4ee63ed531551fdb8f7d72ef8bddd26020a31b9335ecac"
+checksum = "2cf885f3bcf279557fd28b9e2b94cbd12c0eed73a7ba8fbf79b1841a9d1fd4d7"
 dependencies = [
  "log",
  "patina",
@@ -625,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "patina_stacktrace"
-version = "21.1.0"
+version = "21.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba78393a3cc36c95af267663545e19fbe47fe26f774523270a9f448236a5f0d1"
+checksum = "570c7e1ac1738640e4d0c599793c7890cb60327a0ecd64846a01895d619f808a"
 dependencies = [
  "cfg-if",
  "log",
@@ -635,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "patina_test"
-version = "21.1.0"
+version = "21.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b4055c7e1518ee8a70fe0431e31d4f4ef2d9713d85f82e6fec9e30ed375deb"
+checksum = "291ea27e9ab608cc9d77c4d192eb885e81d9a0f565889581b327d7c3487bf6c4"
 dependencies = [
  "linkme",
  "log",
@@ -676,7 +676,7 @@ checksum = "8bb0fd6580eeed0103c054e3fba2c2618ff476943762f28a645b63b8692b21c9"
 
 [[package]]
 name = "qemu_dxe_core"
-version = "3.0.6"
+version = "3.0.7"
 dependencies = [
  "log",
  "patina",
@@ -914,9 +914,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 
 [[package]]
 name = "volatile"
@@ -958,18 +958,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qemu_dxe_core"
-version = "3.0.6"
+version = "3.0.7"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Description

Updates to the latest patina patch release.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
- QEMU Q35 & SBSA boot to EFI shell

## Integration Instructions

- Review the [patina v21.1.1 release notes](https://github.com/OpenDevicePartnership/patina/releases/tag/patina-v21.1.1)