### PR TITLE
r-efi 6.0 Migration: Simplify patina_performance config & add SMBIOS typed records

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aarch64-cpu"
-version = "10.0.0"
+version = "11.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a21cd0131c25c438e19cd6a774adf7e3f64f7f4d723022882facc2dee0f8bc9"
+checksum = "44171e22925ec72b63d86747bc3655c7849a5b8d865c980222128839f45ac034"
 dependencies = [
  "tock-registers",
 ]
@@ -23,7 +23,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c044ecf8760dd8ee5aa92c49cf7534942d289fb1f0247af92b5fbab8ab18a912"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "safe-mmio",
  "thiserror",
  "zerocopy",
@@ -60,9 +60,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"
@@ -185,7 +185,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bafc7e33650ab9f05dcc16325f05d56b8d10393114e31a19a353b86fa60cfe7"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "log",
  "managed",
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "mu_rust_helpers"
-version = "3.0.2"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028b489eb1f6ce61c83feee2cc5e8fb60978115a466c74b84b78aafed6041f34"
+checksum = "8f0939baed11fd68187c2fd292ee166944cdd8472bc8cf261b08e3cbd568d9d6"
 dependencies = [
  "mu_uefi_decompress",
  "mu_uefi_guid",
@@ -300,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "mu_uefi_decompress"
-version = "3.0.2"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b85df261b0b0241dee3c95a186fac29234b0e60bfabef7d57d3099ec2b7cb6"
+checksum = "5592026864b59cc927a2f42ad2721b9820271d6f70ba2e20a796621eb688389f"
 dependencies = [
  "bitvec",
  "log",
@@ -310,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "mu_uefi_guid"
-version = "3.0.2"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091e08bf3b952c68a5d3915d53b4221dc41fad3e00d3eb2020d2dd46f83ae5e2"
+checksum = "392e8c601a9cc36a519c61063a3250e55a3b049a85ee314e49b8a1ad09ff70c3"
 dependencies = [
  "r-efi",
  "uuid",
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "mu_uefi_perf_timer"
-version = "3.0.2"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df471d72676adaa480d61a0c9ed30a844a90842f876c188a0b30cb760d2444aa"
+checksum = "4819bbf728631dd84bc2511c5c3551687db00830998e4937a0ff7af33a591b15"
 dependencies = [
  "aarch64-cpu",
  "log",
@@ -357,9 +357,9 @@ checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "patina"
-version = "21.2.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d833081e3ce92ce59e31e0f851c71b7d7007e20336317984478f20d99630e90"
+checksum = "61ed5c35d03fb46d6b3049dff0eb7a78b8a8b3cfce09fe0e3627ad234d3fc3cb"
 dependencies = [
  "cfg-if",
  "compile-time",
@@ -384,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "patina_acpi"
-version = "21.2.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7eafa302f5e0c0b90c57d2821613f9fc1846a97445191b4549c5d3e5bca282"
+checksum = "976fadb98c3139be0bf584a3a584a57216dfa18930d769566e6f42b2c855ae89"
 dependencies = [
  "log",
  "memoffset",
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "patina_adv_logger"
-version = "21.2.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6382e24f8bd6828c408043b002986974018855775d5c970b355dc98c47248217"
+checksum = "2021f9b6ac77631b5ded17cdc9b86bc36d0cb53c988221d0e02c67a932cd2445"
 dependencies = [
  "log",
  "mu_rust_helpers",
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "patina_debugger"
-version = "21.2.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fbb3025f7dba1f3c5b855ad0b9843ec16d99efd6d3829b2aa4269f13c9391eb"
+checksum = "039063d2a25e058393df325a0f52ee766a60299856136d65eb9f6eb21d6d3b0a"
 dependencies = [
  "bitfield-struct",
  "cfg-if",
@@ -434,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "patina_dxe_core"
-version = "21.2.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119fbeef1c8187a14fb5dcc26164cd5d0ca07faad63666507f0633b778bfb0b2"
+checksum = "7a866acc553bf863a28a7524f7a9d3141643441179f0d37caf7e5071d06b36b4"
 dependencies = [
  "arm-gic",
  "bitfield-struct",
@@ -465,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs"
-version = "21.2.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6776ce1125601ce9454de56a19e8cf1dba2395af3da053e0acade1261f067c5"
+checksum = "2c60cf63519fde3705eb67cc7378596de0ddd6132d8d07b2cee5c57229e505f6"
 dependencies = [
  "log",
  "patina",
@@ -476,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs_extractors"
-version = "21.2.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3074deded35ab581dca562ecadc4bd5970c50b89a1045484b1105c98a41cb166"
+checksum = "a9d10bd1120e350f1b610a3181c16445eaae97994bed4156409ade6a03a43250"
 dependencies = [
  "alloc-no-stdlib",
  "brotli-decompressor",
@@ -492,18 +492,18 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_collections"
-version = "21.2.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460dcd07525866c7f504f298a48e3b6f2e9b239fc1e924962ac12e4e5efdc355"
+checksum = "31c81c7e3077ccbf43d0adeabb8e2404be1e2bc288ccf1818c6ab99e9ab7626a"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "patina_internal_cpu"
-version = "21.2.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5db93dd5b58a195571c6f7568b78ab07c339b7f35e7c2dda379501ea1d4035d"
+checksum = "bea5c7fde5b398b01d3b20cd41482461dcb1f9f7fad2a3b1435cca8d6c4f604e"
 dependencies = [
  "arm-gic",
  "cfg-if",
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_depex"
-version = "21.2.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df2cb66108f2f56e864ea6c958806182e2fe39e0f189aaa7b1de8d37286d18b"
+checksum = "64227e44b6035646744dc3de80b004b86f7bf8347e80425ba8facf96b9ef809f"
 dependencies = [
  "log",
  "r-efi",
@@ -540,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "patina_macro"
-version = "21.2.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "129ea044e9ccf6121023fab8479ab3ee8f01b474eebba0053a256fd6cd6878b5"
+checksum = "0a74965ff8c18ef45a3dad49fba8fb84e58427200b28375783799a4759e8f3f4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -552,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "patina_mm"
-version = "21.2.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684d2809ee7f652ef45dd65c353ba0ac55bc021da03190fbaa70239d808d39fc"
+checksum = "be5bedaa627c20bf1d7eb2d11ce202eadf4a938ec50ac3d6ef9f24604c3ff594"
 dependencies = [
  "cfg-if",
  "log",
@@ -581,16 +581,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5265104f7091071dea0506fe9e733cf347cc49c3ae49eaf0067508297e0e296b"
 dependencies = [
  "bitfield-struct",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "log",
 ]
 
 [[package]]
 name = "patina_performance"
-version = "21.2.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0323f059dd137ba21e49c3778c3dd0e0ffb22d2c318b2bec8b26fa0790f71d2"
+checksum = "643c7833e32a52250773413637731e4c73e8f386fd3ece09f1b0f0e79b264f4a"
 dependencies = [
  "log",
  "mu_rust_helpers",
@@ -604,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "patina_samples"
-version = "21.2.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d646fb3dbcfc75839ace3cc4f3e8dbb816440689ed7c05a4a5d63b3d8cbecc6"
+checksum = "8c5a654a165a8147211e4fbd35d75bb39483db9009d1976e701cb1bcf23a8866"
 dependencies = [
  "log",
  "patina",
@@ -616,10 +616,11 @@ dependencies = [
 
 [[package]]
 name = "patina_smbios"
-version = "21.2.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6756ef1d54a6370a04fbd48c103a0e8ab7e2c1a1f3e176ed39652730393f643"
+checksum = "4552af3b960fd14e83d3d7aac78b197736e45de4168b2869c4d98b674ae6165b"
 dependencies = [
+ "bitfield-struct",
  "log",
  "patina",
  "patina_macro",
@@ -631,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "patina_stacktrace"
-version = "21.2.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39da5dabd54e8d0771c8f495f412279eeff8fb2b1c41c3e72a4806993ec04475"
+checksum = "2b77dcd920470e59372f09d40186ea7040930ef62211cd9f5bdeb0e3c59dc7db"
 dependencies = [
  "cfg-if",
  "log",
@@ -641,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "patina_test"
-version = "21.2.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58284f36a1708a86b0ae4dae2a03e46769820263972fda9f8f434afc788db0e"
+checksum = "03ceadc3ce5f3f45faa99f1a305f7659edeef018199d012d83ea3f9c87e327ba"
 dependencies = [
  "linkme",
  "log",
@@ -714,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -897,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "tock-registers"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b9e2fdb3a1e862c0661768b7ed25390811df1947a8acbfbefe09b47078d93c4"
+checksum = "8d2d250f87fb3fb6f225c907cf54381509f47b40b74b1d1f12d2dccbc915bdfe"
 
 [[package]]
 name = "uart_16550"
@@ -907,7 +908,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e492212ac378a5e00da953718dafb1340d9fbaf4f27d6f3c5cab03d931d1c049"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "rustversion",
  "x86",
 ]
@@ -957,7 +958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7841fa0098ceb15c567d93d3fae292c49e10a7662b4936d5f6a9728594555ba"
 dependencies = [
  "bit_field",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "const_fn",
  "rustversion",
  "volatile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,34 +29,46 @@ name = "qemu_resources"
 path = "src/lib.rs"
 
 [dependencies]
+
+# Patina dependencies
+patina = { version = "22" }
+patina_acpi = { version = "22" }
+patina_adv_logger = { version = "22" }
+patina_debugger = { version = "22" }
+patina_dxe_core = { version = "22" }
+patina_ffs_extractors = { version = "22" }
+patina_mm = { version = "22" }
+patina_performance = { version = "22" }
+patina_samples = { version = "22" }
+patina_smbios = { version = "22" }
+patina_stacktrace = { version = "22" }
+patina_test = { version = "22", features = ["test-runner"] }
+
+# Other dependencies
 log = { version = "^0.4", default-features = false, features = [
-    "release_max_level_info",
+  "release_max_level_info",
 ] }
-patina_acpi = { version = "21" }
-patina_adv_logger = { version = "21" }
-patina_debugger = { version = "21" }
-patina_dxe_core = { version = "21" }
-patina_mm = { version = "21" }
-patina_performance = { version = "21" }
-patina_samples = { version = "21" }
-patina_smbios = { version = "21" }
-patina_test = { version = "21", features = ["test-runner"] }
-patina = { version = "21" }
-patina_ffs_extractors = { version = "21" }
-patina_stacktrace = { version = "21" }
-r-efi = { version = "^5", default-features = false }
+qemu-exit = { version = "4", optional = true }
+r-efi = { version = "^6", default-features = false }
 x86_64 = { version = "=0.15.4", default-features = false, features = [
-  "instructions"
+  "instructions",
 ], optional = true }
 zerocopy = { version = "0.8", features = ["derive"] }
-qemu-exit = { version = "4", optional = true }
 
 [features]
-ci_features = ['build_debugger', 'compatibility_mode_allowed', 'enable_debugger', 'exit_on_patina_test_failure', 'v1_resource_descriptor_support']
+ci_features = [
+  'build_debugger',
+  'compatibility_mode_allowed',
+  'enable_debugger',
+  'exit_on_patina_test_failure',
+  'v1_resource_descriptor_support',
+]
 # Keep the default features here in sync with the features listed in BASE_FEATURES in Makefile.toml
 default = ["compatibility_mode_allowed", "exit_on_patina_test_failure"]
 compatibility_mode_allowed = ["patina_dxe_core/compatibility_mode_allowed"]
-v1_resource_descriptor_support = ["patina_dxe_core/v1_resource_descriptor_support"]
+v1_resource_descriptor_support = [
+  "patina_dxe_core/v1_resource_descriptor_support",
+]
 x64 = ["x86_64"]
 aarch64 = []
 doc = []

--- a/bin/arm_virt_dxe_core.rs
+++ b/bin/arm_virt_dxe_core.rs
@@ -90,22 +90,16 @@ impl ComponentInfo for ArmVirt {
             #[cfg(feature = "exit_on_patina_test_failure")]
             qemu_exit::AArch64::new().exit_failure();
         }));
-        add.component(patina_performance::component::performance_config_provider::PerformanceConfigurationProvider);
-        add.component(patina_performance::component::performance::Performance);
+        add.component(patina_performance::component::Performance::new().with_measurements(
+            patina::performance::Measurement::DriverBindingStart     // Adds driver binding start measurements.
+               | patina::performance::Measurement::DriverBindingStop // Adds driver binding stop measurements.
+               | patina::performance::Measurement::LoadImage         // Adds load image measurements.
+               | patina::performance::Measurement::StartImage, // Adds start image measurements.
+        ));
         add.component(patina_acpi::component::AcpiComponent::default());
     }
 
-    fn configs(mut add: Add<Config>) {
-        add.config(patina_performance::config::PerfConfig {
-            enable_component: true,
-            enabled_measurements: {
-                patina::performance::Measurement::DriverBindingStart         // Adds driver binding start measurements.
-               | patina::performance::Measurement::DriverBindingStop        // Adds driver binding stop measurements.
-               | patina::performance::Measurement::LoadImage                // Adds load image measurements.
-               | patina::performance::Measurement::StartImage // Adds start image measurements.
-            },
-        })
-    }
+    fn configs(_add: Add<Config>) {}
 }
 
 impl PlatformInfo for ArmVirt {

--- a/bin/q35_dxe_core.rs
+++ b/bin/q35_dxe_core.rs
@@ -93,15 +93,6 @@ impl ComponentInfo for Q35 {
             updatable_buffer_id: None,
             comm_buffers: vec![],
         });
-        add.config(patina_performance::config::PerfConfig {
-            enable_component: true,
-            enabled_measurements: {
-                patina::performance::Measurement::DriverBindingStart         // Adds driver binding start measurements.
-               | patina::performance::Measurement::DriverBindingStop        // Adds driver binding stop measurements.
-               | patina::performance::Measurement::LoadImage                // Adds load image measurements.
-               | patina::performance::Measurement::StartImage // Adds start image measurements.
-            },
-        })
     }
 
     fn components(mut add: Add<Component>) {
@@ -111,8 +102,12 @@ impl ComponentInfo for Q35 {
         add.component(patina_mm::component::sw_mmi_manager::SwMmiManager::new());
         add.component(patina_mm::component::communicator::MmCommunicator::new());
         add.component(q35_services::mm_test::QemuQ35MmTest::new());
-        add.component(patina_performance::component::performance_config_provider::PerformanceConfigurationProvider);
-        add.component(patina_performance::component::performance::Performance);
+        add.component(patina_performance::component::Performance::new().with_measurements(
+            patina::performance::Measurement::DriverBindingStart     // Adds driver binding start measurements.
+               | patina::performance::Measurement::DriverBindingStop // Adds driver binding stop measurements.
+               | patina::performance::Measurement::LoadImage         // Adds load image measurements.
+               | patina::performance::Measurement::StartImage, // Adds start image measurements.
+        ));
         add.component(patina_smbios::component::SmbiosProvider::new(3, 9));
         add.component(q35_services::smbios_platform::Q35SmbiosPlatform::new());
         add.component(patina_acpi::component::AcpiComponent::default());

--- a/bin/sbsa_dxe_core.rs
+++ b/bin/sbsa_dxe_core.rs
@@ -81,22 +81,16 @@ impl ComponentInfo for Sbsa {
             #[cfg(feature = "exit_on_patina_test_failure")]
             qemu_exit::AArch64::new().exit_failure();
         }));
-        add.component(patina_performance::component::performance_config_provider::PerformanceConfigurationProvider);
-        add.component(patina_performance::component::performance::Performance);
+        add.component(patina_performance::component::Performance::new().with_measurements(
+            patina::performance::Measurement::DriverBindingStart     // Adds driver binding start measurements.
+               | patina::performance::Measurement::DriverBindingStop // Adds driver binding stop measurements.
+               | patina::performance::Measurement::LoadImage         // Adds load image measurements.
+               | patina::performance::Measurement::StartImage, // Adds start image measurements.
+        ));
         add.component(patina_acpi::component::AcpiComponent::default());
     }
 
-    fn configs(mut add: Add<Config>) {
-        add.config(patina_performance::config::PerfConfig {
-            enable_component: true,
-            enabled_measurements: {
-                patina::performance::Measurement::DriverBindingStart         // Adds driver binding start measurements.
-               | patina::performance::Measurement::DriverBindingStop        // Adds driver binding stop measurements.
-               | patina::performance::Measurement::LoadImage                // Adds load image measurements.
-               | patina::performance::Measurement::StartImage // Adds start image measurements.
-            },
-        })
-    }
+    fn configs(_add: Add<Config>) {}
 }
 
 impl PlatformInfo for Sbsa {

--- a/src/armvirt/component/service/smbios_platform.rs
+++ b/src/armvirt/component/service/smbios_platform.rs
@@ -21,6 +21,15 @@ use patina_smbios::{
         Type4ProcessorInformation, Type7CacheInformation, Type16PhysicalMemoryArray, Type17MemoryDevice,
         Type19MemoryArrayMappedAddress,
     },
+    smbios_types::{
+        AssociativityField, BiosCharacteristics, BiosCharacteristicsExt1, BiosCharacteristicsExt2, BoardType,
+        BootUpState, CacheConfiguration, CacheErrorCorrectionType, CacheSize, CacheSize2, CacheSramTypeData,
+        ExtendedBiosRomSize, FeatureFlags, MemoryArrayErrorCorrectionType, MemoryArrayLocation, MemoryArrayUse,
+        MemoryCapability, MemoryDeviceAttributes, MemoryDeviceTechnology, MemoryDeviceType, MemoryDeviceTypeDetails,
+        MemoryFormFactor, PowerSupplyState, ProcessorCharacteristics, ProcessorFamilyData, ProcessorInformationStatus,
+        ProcessorTypeData, ProcessorUpgrade, ProcessorVoltage, SecurityStatus, SystemCacheType, ThermalState,
+        WakeUpType,
+    },
 };
 
 /// Arm Virt platform SMBIOS record provider.
@@ -47,14 +56,19 @@ impl ArmVirtSmbiosPlatform {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: 0x08,
-            characteristics_ext1: 0x03,
-            characteristics_ext2: 0x03,
+            characteristics: BiosCharacteristics::new().with_pci_supported(true),
+            characteristics_ext1: BiosCharacteristicsExt1::new()
+                .with_acpi_supported(true)
+                .with_usb_legacy_supported(true)
+                .with_smart_battery_supported(true),
+            characteristics_ext2: BiosCharacteristicsExt2::new()
+                .with_bios_boot_specification_supported(true)
+                .with_uefi_spec_supported(true),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: 0,
+            extended_bios_rom_size: ExtendedBiosRomSize::new(),
             string_pool: vec![
                 String::from("Patina Firmware"),
                 String::from(env!("CARGO_PKG_VERSION")),
@@ -77,7 +91,7 @@ impl ArmVirtSmbiosPlatform {
             version: 3,
             serial_number: 4,
             uuid: [0; 16],
-            wake_up_type: 0x06,
+            wake_up_type: WakeUpType::PowerSwitch,
             sku_number: 5,
             family: 6,
             string_pool: vec![
@@ -103,10 +117,10 @@ impl ArmVirtSmbiosPlatform {
             version: 2,
             serial_number: 3,
             asset_tag_number: 4,
-            bootup_state: 0x03,
-            power_supply_state: 0x03,
-            thermal_state: 0x03,
-            security_status: 0x02,
+            bootup_state: BootUpState::Safe,
+            power_supply_state: PowerSupplyState::Safe,
+            thermal_state: ThermalState::Safe,
+            security_status: SecurityStatus::Unknown,
             oem_defined: 0x00000000,
             height: 0x00,
             number_of_power_cords: 0x01,
@@ -136,10 +150,10 @@ impl ArmVirtSmbiosPlatform {
             version: 3,
             serial_number: 4,
             asset_tag: 5,
-            feature_flags: 0x01,
+            feature_flags: FeatureFlags::new().with_hosting_board(true),
             location_in_chassis: 6,
             chassis_handle: type3_handle,
-            board_type: 0x0A,
+            board_type: BoardType::Motherboard,
             contained_object_handles: 0,
             string_pool: vec![
                 String::from("Example Corporation"),
@@ -160,17 +174,20 @@ impl ArmVirtSmbiosPlatform {
         let l1_cache = Type7CacheInformation {
             header: SmbiosTableHeader::new(7, 0, SMBIOS_HANDLE_PI_RESERVED),
             socket_designation: 1,
-            cache_configuration: 0x0180, // L1, enabled, write-back
-            maximum_cache_size: 64,      // 64 KB
-            installed_size: 64,
-            supported_sram_type: 0x0002, // Unknown
-            current_sram_type: 0x0002,
+            cache_configuration: CacheConfiguration::new()
+                .with_cache_level(0)
+                .with_enabled_disabled(true)
+                .with_operational_mode(1), // L1, enabled, write-back
+            maximum_cache_size: CacheSize::new().with_max_size(64), // 64 KB
+            installed_size: CacheSize::new().with_max_size(64),
+            supported_sram_type: CacheSramTypeData::new().with_unknown(true),
+            current_sram_type: CacheSramTypeData::new().with_unknown(true),
             cache_speed: 0,
-            error_correction_type: 0x05, // Single-bit ECC
-            system_cache_type: 0x05,     // Unified
-            associativity: 0x06,         // 8-way
-            maximum_cache_size2: 64,
-            installed_cache_size2: 64,
+            error_correction_type: CacheErrorCorrectionType::SingleBitEcc,
+            system_cache_type: SystemCacheType::Unified,
+            associativity: AssociativityField::FullyAssociative,
+            maximum_cache_size2: CacheSize2::new().with_max_size(64),
+            installed_size2: CacheSize2::new().with_max_size(64),
             string_pool: vec![String::from("L1 Cache")],
         };
 
@@ -186,17 +203,20 @@ impl ArmVirtSmbiosPlatform {
         let l2_cache = Type7CacheInformation {
             header: SmbiosTableHeader::new(7, 0, SMBIOS_HANDLE_PI_RESERVED),
             socket_designation: 1,
-            cache_configuration: 0x0181, // L2, enabled, write-back
-            maximum_cache_size: 256,     // 256 KB
-            installed_size: 256,
-            supported_sram_type: 0x0002,
-            current_sram_type: 0x0002,
+            cache_configuration: CacheConfiguration::new()
+                .with_cache_level(1)
+                .with_enabled_disabled(true)
+                .with_operational_mode(1), // L2, enabled, write-back
+            maximum_cache_size: CacheSize::new().with_max_size(256), // 256 KB
+            installed_size: CacheSize::new().with_max_size(256),
+            supported_sram_type: CacheSramTypeData::new().with_unknown(true),
+            current_sram_type: CacheSramTypeData::new().with_unknown(true),
             cache_speed: 0,
-            error_correction_type: 0x05, // Single-bit ECC
-            system_cache_type: 0x05,     // Unified
-            associativity: 0x06,         // 8-way
-            maximum_cache_size2: 256,
-            installed_cache_size2: 256,
+            error_correction_type: CacheErrorCorrectionType::SingleBitEcc,
+            system_cache_type: SystemCacheType::Unified,
+            associativity: AssociativityField::FullyAssociative,
+            maximum_cache_size2: CacheSize2::new().with_max_size(256),
+            installed_size2: CacheSize2::new().with_max_size(256),
             string_pool: vec![String::from("L2 Cache")],
         };
 
@@ -213,17 +233,17 @@ impl ArmVirtSmbiosPlatform {
         let processor_info = Type4ProcessorInformation {
             header: SmbiosTableHeader::new(4, 0, SMBIOS_HANDLE_PI_RESERVED),
             socket_designation: 1,
-            processor_type: 0x03,   // Central Processor
+            processor_type: ProcessorTypeData::CentralProcessor,
             processor_family: 0xFE, // Use processor_family2
             processor_manufacturer: 2,
             processor_id: [0u8; 8],
             processor_version: 3,
-            voltage: 0x80,     // Legacy mode, voltage unknown
+            voltage: ProcessorVoltage::new().with_processor_voltage_indicate_legacy(true),
             external_clock: 0, // Unknown
             max_speed: 2000,
             current_speed: 2000,
-            status: 0x41,            // CPU Enabled, Populated
-            processor_upgrade: 0x06, // None
+            status: ProcessorInformationStatus::new().with_cpu_status(1).with_cpu_socket_populated(true),
+            processor_upgrade: ProcessorUpgrade::NoUpgrade, // None
             l1_cache_handle,
             l2_cache_handle,
             l3_cache_handle: 0xFFFF, // Not provided
@@ -233,8 +253,8 @@ impl ArmVirtSmbiosPlatform {
             core_count: 1,
             core_enabled: 1,
             thread_count: 1,
-            processor_characteristics: 0x04, // 64-bit capable
-            processor_family2: 0x0101,       // ARMv8
+            processor_characteristics: ProcessorCharacteristics::new().with_capable_64bit(true),
+            processor_family2: ProcessorFamilyData::ARMv8,
             core_count2: 1,
             core_enabled2: 1,
             thread_count2: 1,
@@ -256,9 +276,9 @@ impl ArmVirtSmbiosPlatform {
         // Type 16: Physical Memory Array
         let memory_array = Type16PhysicalMemoryArray {
             header: SmbiosTableHeader::new(16, 0, SMBIOS_HANDLE_PI_RESERVED),
-            location: 0x03,                          // System board
-            use_field: 0x03,                         // System memory
-            memory_error_correction: 0x03,           // None
+            location: MemoryArrayLocation::SystemBoard,
+            use_field: MemoryArrayUse::SystemMemory,
+            memory_error_correction: MemoryArrayErrorCorrectionType::NoEcc,
             maximum_capacity: 0x00100000,            // 1 GB in KB
             memory_error_information_handle: 0xFFFE, // Not provided
             number_of_memory_devices: 1,
@@ -285,26 +305,26 @@ impl ArmVirtSmbiosPlatform {
                 memory_error_information_handle: 0xFFFE, // Not provided
                 total_width: 64,
                 data_width: 64,
-                size: 0x0400,      // 1024 MB
-                form_factor: 0x09, // DIMM
+                size: 0x0400, // 1024 MB
+                form_factor: MemoryFormFactor::Dimm,
                 device_set: 0,
                 device_locator: 1,
                 bank_locator: 2,
-                memory_type: 0x1A,   // DDR4
-                type_detail: 0x0080, // Synchronous
+                memory_type: MemoryDeviceType::Ddr4,
+                type_detail: MemoryDeviceTypeDetails::new().with_synchronous(true),
                 speed: 3200,
                 manufacturer: 3,
                 serial_number: 4,
                 asset_tag: 5,
                 part_number: 6,
-                attributes: 0x01, // Single rank
+                attributes: MemoryDeviceAttributes::new().with_rank(1),
                 extended_size: 0,
                 configured_memory_clock_speed: 3200,
                 minimum_voltage: 1200,
                 maximum_voltage: 1200,
                 configured_voltage: 1200,
-                memory_technology: 0x02,                  // DRAM
-                memory_operating_mode_capability: 0x0004, // Volatile
+                memory_technology: MemoryDeviceTechnology::Unknown,
+                memory_operating_mode_capability: MemoryCapability::new().with_volatile_memory(true),
                 firmware_version: 7,
                 module_manufacturer_id: 0,
                 module_product_id: 0,

--- a/src/q35/component/service/smbios_platform.rs
+++ b/src/q35/component/service/smbios_platform.rs
@@ -24,6 +24,10 @@ use patina_smbios::{
     smbios_record::{
         Type0PlatformFirmwareInformation, Type1SystemInformation, Type2BaseboardInformation, Type3SystemEnclosure,
     },
+    smbios_types::{
+        BiosCharacteristics, BiosCharacteristicsExt1, BiosCharacteristicsExt2, BoardType, BootUpState,
+        ExtendedBiosRomSize, FeatureFlags, PowerSupplyState, SecurityStatus, ThermalState, WakeUpType,
+    },
 };
 
 /// Q35 platform SMBIOS component that populates and publishes SMBIOS tables.
@@ -60,20 +64,19 @@ impl Q35SmbiosPlatform {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF, // 16MB
-            // BIOS Characteristics (SMBIOS spec 7.1.1)
-            // Bit 3: BIOS Characteristics are supported
-            characteristics: 0x08,
-            // BIOS Characteristics Extension Byte 1 (SMBIOS spec 7.1.2.1)
-            // Bit 0: ACPI supported, Bit 1: USB Legacy supported
-            characteristics_ext1: 0x03,
-            // BIOS Characteristics Extension Byte 2 (SMBIOS spec 7.1.2.2)
-            // Bit 0: BIOS Boot Specification supported, Bit 1: Function key-initiated network boot supported
-            characteristics_ext2: 0x03,
+            characteristics: BiosCharacteristics::new().with_pci_supported(true),
+            characteristics_ext1: BiosCharacteristicsExt1::new()
+                .with_acpi_supported(true)
+                .with_usb_legacy_supported(true)
+                .with_smart_battery_supported(true),
+            characteristics_ext2: BiosCharacteristicsExt2::new()
+                .with_bios_boot_specification_supported(true)
+                .with_uefi_spec_supported(true),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: 0,
+            extended_bios_rom_size: ExtendedBiosRomSize::new(),
             string_pool: vec![
                 String::from("Patina Firmware"),
                 String::from(env!("CARGO_PKG_VERSION")),
@@ -94,7 +97,7 @@ impl Q35SmbiosPlatform {
             version: 3,
             serial_number: 4,
             uuid: [0; 16],
-            wake_up_type: 0x06, // Power Switch
+            wake_up_type: WakeUpType::PowerSwitch,
             sku_number: 5,
             family: 6,
             string_pool: vec![
@@ -119,10 +122,10 @@ impl Q35SmbiosPlatform {
             version: 2,
             serial_number: 3,
             asset_tag_number: 4,
-            bootup_state: 0x03,
-            power_supply_state: 0x03,
-            thermal_state: 0x03,
-            security_status: 0x02,
+            bootup_state: BootUpState::Safe,
+            power_supply_state: PowerSupplyState::Safe,
+            thermal_state: ThermalState::Safe,
+            security_status: SecurityStatus::Unknown,
             oem_defined: 0x00000000,
             height: 0x00,
             number_of_power_cords: 0x01,
@@ -152,10 +155,10 @@ impl Q35SmbiosPlatform {
             version: 3,
             serial_number: 4,
             asset_tag: 5,
-            feature_flags: 0x01, // Board is a hosting board
+            feature_flags: FeatureFlags::new().with_hosting_board(true),
             location_in_chassis: 6,
             chassis_handle: type3_handle,
-            board_type: 0x0A, // Motherboard
+            board_type: BoardType::Motherboard,
             contained_object_handles: 0,
             string_pool: vec![
                 String::from("Example Corporation"),

--- a/src/sbsa/component/service/smbios_platform.rs
+++ b/src/sbsa/component/service/smbios_platform.rs
@@ -21,6 +21,15 @@ use patina_smbios::{
         Type4ProcessorInformation, Type7CacheInformation, Type16PhysicalMemoryArray, Type17MemoryDevice,
         Type19MemoryArrayMappedAddress,
     },
+    smbios_types::{
+        AssociativityField, BiosCharacteristics, BiosCharacteristicsExt1, BiosCharacteristicsExt2, BoardType,
+        BootUpState, CacheConfiguration, CacheErrorCorrectionType, CacheSize, CacheSize2, CacheSramTypeData,
+        ExtendedBiosRomSize, FeatureFlags, MemoryArrayErrorCorrectionType, MemoryArrayLocation, MemoryArrayUse,
+        MemoryCapability, MemoryDeviceAttributes, MemoryDeviceTechnology, MemoryDeviceType, MemoryDeviceTypeDetails,
+        MemoryFormFactor, PowerSupplyState, ProcessorCharacteristics, ProcessorFamilyData, ProcessorInformationStatus,
+        ProcessorTypeData, ProcessorUpgrade, ProcessorVoltage, SecurityStatus, SystemCacheType, ThermalState,
+        WakeUpType,
+    },
 };
 
 /// SBSA platform SMBIOS record provider.
@@ -47,14 +56,19 @@ impl SbsaSmbiosPlatform {
             bios_starting_address_segment: 0xE800,
             firmware_release_date: 3,
             firmware_rom_size: 0xFF,
-            characteristics: 0x08,
-            characteristics_ext1: 0x03,
-            characteristics_ext2: 0x03,
+            characteristics: BiosCharacteristics::new().with_pci_supported(true),
+            characteristics_ext1: BiosCharacteristicsExt1::new()
+                .with_acpi_supported(true)
+                .with_usb_legacy_supported(true)
+                .with_smart_battery_supported(true),
+            characteristics_ext2: BiosCharacteristicsExt2::new()
+                .with_bios_boot_specification_supported(true)
+                .with_uefi_spec_supported(true),
             system_bios_major_release: 1,
             system_bios_minor_release: 0,
             embedded_controller_major_release: 0xFF,
             embedded_controller_minor_release: 0xFF,
-            extended_bios_rom_size: 0,
+            extended_bios_rom_size: ExtendedBiosRomSize::new(),
             string_pool: vec![
                 String::from("Patina Firmware"),
                 String::from(env!("CARGO_PKG_VERSION")),
@@ -77,7 +91,7 @@ impl SbsaSmbiosPlatform {
             version: 3,
             serial_number: 4,
             uuid: [0; 16],
-            wake_up_type: 0x06,
+            wake_up_type: WakeUpType::PowerSwitch,
             sku_number: 5,
             family: 6,
             string_pool: vec![
@@ -103,10 +117,10 @@ impl SbsaSmbiosPlatform {
             version: 2,
             serial_number: 3,
             asset_tag_number: 4,
-            bootup_state: 0x03,
-            power_supply_state: 0x03,
-            thermal_state: 0x03,
-            security_status: 0x02,
+            bootup_state: BootUpState::Safe,
+            power_supply_state: PowerSupplyState::Safe,
+            thermal_state: ThermalState::Safe,
+            security_status: SecurityStatus::Unknown,
             oem_defined: 0x00000000,
             height: 0x00,
             number_of_power_cords: 0x01,
@@ -136,10 +150,10 @@ impl SbsaSmbiosPlatform {
             version: 3,
             serial_number: 4,
             asset_tag: 5,
-            feature_flags: 0x01,
+            feature_flags: FeatureFlags::new().with_hosting_board(true),
             location_in_chassis: 6,
             chassis_handle: type3_handle,
-            board_type: 0x0A,
+            board_type: BoardType::Motherboard,
             contained_object_handles: 0,
             string_pool: vec![
                 String::from("Example Corporation"),
@@ -160,17 +174,20 @@ impl SbsaSmbiosPlatform {
         let l1_cache = Type7CacheInformation {
             header: SmbiosTableHeader::new(7, 0, SMBIOS_HANDLE_PI_RESERVED),
             socket_designation: 1,
-            cache_configuration: 0x0180, // L1, enabled, write-back
-            maximum_cache_size: 64,      // 64 KB
-            installed_size: 64,
-            supported_sram_type: 0x0002, // Unknown
-            current_sram_type: 0x0002,
+            cache_configuration: CacheConfiguration::new()
+                .with_cache_level(0)
+                .with_enabled_disabled(true)
+                .with_operational_mode(1), // L1, enabled, write-back
+            maximum_cache_size: CacheSize::new().with_max_size(64), // 64 KB
+            installed_size: CacheSize::new().with_max_size(64),
+            supported_sram_type: CacheSramTypeData::new().with_unknown(true),
+            current_sram_type: CacheSramTypeData::new().with_unknown(true),
             cache_speed: 0,
-            error_correction_type: 0x05, // Single-bit ECC
-            system_cache_type: 0x05,     // Unified
-            associativity: 0x06,         // 8-way
-            maximum_cache_size2: 64,
-            installed_cache_size2: 64,
+            error_correction_type: CacheErrorCorrectionType::SingleBitEcc,
+            system_cache_type: SystemCacheType::Unified,
+            associativity: AssociativityField::FullyAssociative,
+            maximum_cache_size2: CacheSize2::new().with_max_size(64),
+            installed_size2: CacheSize2::new().with_max_size(64),
             string_pool: vec![String::from("L1 Cache")],
         };
 
@@ -186,17 +203,20 @@ impl SbsaSmbiosPlatform {
         let l2_cache = Type7CacheInformation {
             header: SmbiosTableHeader::new(7, 0, SMBIOS_HANDLE_PI_RESERVED),
             socket_designation: 1,
-            cache_configuration: 0x0181, // L2, enabled, write-back
-            maximum_cache_size: 256,     // 256 KB
-            installed_size: 256,
-            supported_sram_type: 0x0002,
-            current_sram_type: 0x0002,
+            cache_configuration: CacheConfiguration::new()
+                .with_cache_level(1)
+                .with_enabled_disabled(true)
+                .with_operational_mode(1), // L2, enabled, write-back
+            maximum_cache_size: CacheSize::new().with_max_size(256), // 256 KB
+            installed_size: CacheSize::new().with_max_size(256),
+            supported_sram_type: CacheSramTypeData::new().with_unknown(true),
+            current_sram_type: CacheSramTypeData::new().with_unknown(true),
             cache_speed: 0,
-            error_correction_type: 0x05, // Single-bit ECC
-            system_cache_type: 0x05,     // Unified
-            associativity: 0x06,         // 8-way
-            maximum_cache_size2: 256,
-            installed_cache_size2: 256,
+            error_correction_type: CacheErrorCorrectionType::SingleBitEcc,
+            system_cache_type: SystemCacheType::Unified,
+            associativity: AssociativityField::FullyAssociative,
+            maximum_cache_size2: CacheSize2::new().with_max_size(256),
+            installed_size2: CacheSize2::new().with_max_size(256),
             string_pool: vec![String::from("L2 Cache")],
         };
 
@@ -213,17 +233,17 @@ impl SbsaSmbiosPlatform {
         let processor_info = Type4ProcessorInformation {
             header: SmbiosTableHeader::new(4, 0, SMBIOS_HANDLE_PI_RESERVED),
             socket_designation: 1,
-            processor_type: 0x03,   // Central Processor
+            processor_type: ProcessorTypeData::CentralProcessor,
             processor_family: 0xFE, // Use processor_family2
             processor_manufacturer: 2,
             processor_id: [0u8; 8],
             processor_version: 3,
-            voltage: 0x80,     // Legacy mode, voltage unknown
+            voltage: ProcessorVoltage::new().with_processor_voltage_indicate_legacy(true),
             external_clock: 0, // Unknown
             max_speed: 2000,
             current_speed: 2000,
-            status: 0x41,            // CPU Enabled, Populated
-            processor_upgrade: 0x06, // None
+            status: ProcessorInformationStatus::new().with_cpu_status(1).with_cpu_socket_populated(true),
+            processor_upgrade: ProcessorUpgrade::NoUpgrade, // None
             l1_cache_handle,
             l2_cache_handle,
             l3_cache_handle: 0xFFFF, // Not provided
@@ -233,8 +253,8 @@ impl SbsaSmbiosPlatform {
             core_count: 1,
             core_enabled: 1,
             thread_count: 1,
-            processor_characteristics: 0x04, // 64-bit capable
-            processor_family2: 0x0100,       // ARMv8
+            processor_characteristics: ProcessorCharacteristics::new().with_capable_64bit(true), // 64-bit capable
+            processor_family2: ProcessorFamilyData::ARMv8,
             core_count2: 1,
             core_enabled2: 1,
             thread_count2: 1,
@@ -256,9 +276,9 @@ impl SbsaSmbiosPlatform {
         // Type 16: Physical Memory Array
         let memory_array = Type16PhysicalMemoryArray {
             header: SmbiosTableHeader::new(16, 0, SMBIOS_HANDLE_PI_RESERVED),
-            location: 0x03,                          // System board
-            use_field: 0x03,                         // System memory
-            memory_error_correction: 0x03,           // None
+            location: MemoryArrayLocation::SystemBoard,
+            use_field: MemoryArrayUse::SystemMemory,
+            memory_error_correction: MemoryArrayErrorCorrectionType::NoEcc,
             maximum_capacity: 0x00100000,            // 1 GB in KB
             memory_error_information_handle: 0xFFFE, // Not provided
             number_of_memory_devices: 1,
@@ -282,26 +302,26 @@ impl SbsaSmbiosPlatform {
             memory_error_information_handle: 0xFFFE, // Not provided
             total_width: 64,
             data_width: 64,
-            size: 0x0400,      // 1024 MB
-            form_factor: 0x09, // DIMM
+            size: 0x0400, // 1024 MB
+            form_factor: MemoryFormFactor::Dimm,
             device_set: 0,
             device_locator: 1,
             bank_locator: 2,
-            memory_type: 0x1A,   // DDR4
-            type_detail: 0x0080, // Synchronous
+            memory_type: MemoryDeviceType::Ddr4,
+            type_detail: MemoryDeviceTypeDetails::new().with_synchronous(true),
             speed: 3200,
             manufacturer: 3,
             serial_number: 4,
             asset_tag: 5,
             part_number: 6,
-            attributes: 0x01, // Single rank
+            attributes: MemoryDeviceAttributes::new().with_rank(1),
             extended_size: 0,
             configured_memory_clock_speed: 3200,
             minimum_voltage: 1200,
             maximum_voltage: 1200,
             configured_voltage: 1200,
-            memory_technology: 0x02,                  // DRAM
-            memory_operating_mode_capability: 0x0004, // Volatile
+            memory_technology: MemoryDeviceTechnology::Unknown,
+            memory_operating_mode_capability: MemoryCapability::new().with_volatile_memory(true),
             firmware_version: 7,
             module_manufacturer_id: 0,
             module_product_id: 0,


### PR DESCRIPTION
## Description

Consume below major changes from Patina 
- patina_performance: Simplify configuration
- patina_smbios: Add SMBIOS types
- R-EFI 6.0 Migration
---
- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booted to UEFI SHELL on q35/SBSA

## Integration Instructions

Will merge this once https://github.com/OpenDevicePartnership/patina/pull/1548 is merged and patina release 22 is made. 