### PR TITLE
v3.0.8: Update to patina v21.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c044ecf8760dd8ee5aa92c49cf7534942d289fb1f0247af92b5fbab8ab18a912"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "safe-mmio",
  "thiserror",
  "zerocopy",
@@ -60,9 +60,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "bitvec"
@@ -185,7 +185,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bafc7e33650ab9f05dcc16325f05d56b8d10393114e31a19a353b86fa60cfe7"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "cfg-if",
  "log",
  "managed",
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "managed"
@@ -357,9 +357,9 @@ checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "patina"
-version = "21.1.1"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec23b00420d750e81d236a5e0f44d4b3bc6da36b4f7196a9e12cf5acf968ebd"
+checksum = "7d833081e3ce92ce59e31e0f851c71b7d7007e20336317984478f20d99630e90"
 dependencies = [
  "cfg-if",
  "compile-time",
@@ -384,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "patina_acpi"
-version = "21.1.1"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c7297f34a614e2f306400fdea36a3649f30b8cc528170d244ce09db60380aa"
+checksum = "7f7eafa302f5e0c0b90c57d2821613f9fc1846a97445191b4549c5d3e5bca282"
 dependencies = [
  "log",
  "memoffset",
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "patina_adv_logger"
-version = "21.1.1"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389bc04315d0f70f926c6264eb9437acc1cfd134c8c3cb58155d3dc1a33a9d60"
+checksum = "6382e24f8bd6828c408043b002986974018855775d5c970b355dc98c47248217"
 dependencies = [
  "log",
  "mu_rust_helpers",
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "patina_debugger"
-version = "21.1.1"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c440f681186cec8f89b7b38f3acc375c5589a77fad76e89a93ba9d3b328d631c"
+checksum = "5fbb3025f7dba1f3c5b855ad0b9843ec16d99efd6d3829b2aa4269f13c9391eb"
 dependencies = [
  "bitfield-struct",
  "cfg-if",
@@ -434,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "patina_dxe_core"
-version = "21.1.1"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e442086b63d05ddf95a02e3a87b9fed802910eb55e5c8a2aa5af78c24a1777a6"
+checksum = "119fbeef1c8187a14fb5dcc26164cd5d0ca07faad63666507f0633b778bfb0b2"
 dependencies = [
  "arm-gic",
  "bitfield-struct",
@@ -465,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs"
-version = "21.1.1"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9213b7a2f702b569762a29538b252e1f7209adf4de6a7899fc32a441635e441"
+checksum = "b6776ce1125601ce9454de56a19e8cf1dba2395af3da053e0acade1261f067c5"
 dependencies = [
  "log",
  "patina",
@@ -476,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs_extractors"
-version = "21.1.1"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e03d7c79f79291604bb489b2360a7fa1deff3342b05ffe21bb2b8c9d0a8c7715"
+checksum = "3074deded35ab581dca562ecadc4bd5970c50b89a1045484b1105c98a41cb166"
 dependencies = [
  "alloc-no-stdlib",
  "brotli-decompressor",
@@ -492,18 +492,18 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_collections"
-version = "21.1.1"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ff33fa3f8b3c6687160c43bc3c4d81ad9919b99ebc2052fa810c1f75a70f069"
+checksum = "460dcd07525866c7f504f298a48e3b6f2e9b239fc1e924962ac12e4e5efdc355"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "patina_internal_cpu"
-version = "21.1.1"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8161983fca545715373f1c14e3cb21f469e156e1415fcccf615b86a131f1b612"
+checksum = "d5db93dd5b58a195571c6f7568b78ab07c339b7f35e7c2dda379501ea1d4035d"
 dependencies = [
  "arm-gic",
  "cfg-if",
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_depex"
-version = "21.1.1"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe860f312315bf1ed0abe4157613552169aa08f4dbe14b4609631b75fcea488"
+checksum = "7df2cb66108f2f56e864ea6c958806182e2fe39e0f189aaa7b1de8d37286d18b"
 dependencies = [
  "log",
  "r-efi",
@@ -540,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "patina_macro"
-version = "21.1.1"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10feb0e24c831f028f4de2e86b1b592ec0dfb432c3e4d44bd47f4b55aef98fa4"
+checksum = "129ea044e9ccf6121023fab8479ab3ee8f01b474eebba0053a256fd6cd6878b5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -552,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "patina_mm"
-version = "21.1.1"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a4002faad67ab194c3d3af8d7c127c3c8ba341580bff0024d46396fcaf0d409"
+checksum = "684d2809ee7f652ef45dd65c353ba0ac55bc021da03190fbaa70239d808d39fc"
 dependencies = [
  "cfg-if",
  "log",
@@ -581,16 +581,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5265104f7091071dea0506fe9e733cf347cc49c3ae49eaf0067508297e0e296b"
 dependencies = [
  "bitfield-struct",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "cfg-if",
  "log",
 ]
 
 [[package]]
 name = "patina_performance"
-version = "21.1.1"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c4d3d2d08ad89ef98ea69dcd16c319fbfe8c2334b2911558b67c4ddc2ed53c"
+checksum = "b0323f059dd137ba21e49c3778c3dd0e0ffb22d2c318b2bec8b26fa0790f71d2"
 dependencies = [
  "log",
  "mu_rust_helpers",
@@ -604,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "patina_samples"
-version = "21.1.1"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ad10a4e2ed5336c5ddb1d5d202c80cb3ac6653c13e07966c93f35979afa0c0"
+checksum = "2d646fb3dbcfc75839ace3cc4f3e8dbb816440689ed7c05a4a5d63b3d8cbecc6"
 dependencies = [
  "log",
  "patina",
@@ -616,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "patina_smbios"
-version = "21.1.1"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf885f3bcf279557fd28b9e2b94cbd12c0eed73a7ba8fbf79b1841a9d1fd4d7"
+checksum = "b6756ef1d54a6370a04fbd48c103a0e8ab7e2c1a1f3e176ed39652730393f643"
 dependencies = [
  "log",
  "patina",
@@ -631,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "patina_stacktrace"
-version = "21.1.1"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570c7e1ac1738640e4d0c599793c7890cb60327a0ecd64846a01895d619f808a"
+checksum = "39da5dabd54e8d0771c8f495f412279eeff8fb2b1c41c3e72a4806993ec04475"
 dependencies = [
  "cfg-if",
  "log",
@@ -641,9 +641,9 @@ dependencies = [
 
 [[package]]
 name = "patina_test"
-version = "21.1.1"
+version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ea27e9ab608cc9d77c4d192eb885e81d9a0f565889581b327d7c3487bf6c4"
+checksum = "d58284f36a1708a86b0ae4dae2a03e46769820263972fda9f8f434afc788db0e"
 dependencies = [
  "linkme",
  "log",
@@ -682,7 +682,7 @@ checksum = "8189cbf0422ac15d7d544ed5f331fbe4e5b9da88133568fd359083b186a547f3"
 
 [[package]]
 name = "qemu_dxe_core"
-version = "3.0.7"
+version = "3.0.8"
 dependencies = [
  "log",
  "patina",
@@ -907,7 +907,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e492212ac378a5e00da953718dafb1340d9fbaf4f27d6f3c5cab03d931d1c049"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "rustversion",
  "x86",
 ]
@@ -957,7 +957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7841fa0098ceb15c567d93d3fae292c49e10a7662b4936d5f6a9728594555ba"
 dependencies = [
  "bit_field",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "const_fn",
  "rustversion",
  "volatile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qemu_dxe_core"
-version = "3.0.7"
+version = "3.0.8"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Description

Updates to the latest patina patch release.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
- Boot to EFI shell on QEMU Q35 and SBSA

## Integration Instructions

- N/A