### PR TITLE
v3.0.9: Update to patina v22.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,9 +157,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "fallible-streaming-iterator"
@@ -212,12 +209,6 @@ checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
 ]
-
-[[package]]
-name = "itoa"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lazy_static"
@@ -357,9 +348,9 @@ checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "patina"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ed5c35d03fb46d6b3049dff0eb7a78b8a8b3cfce09fe0e3627ad234d3fc3cb"
+checksum = "ab8e4a036f833831dbc6ccf63e043bc748d96d9b705babed625d8f7a28894c4b"
 dependencies = [
  "cfg-if",
  "compile-time",
@@ -384,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "patina_acpi"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976fadb98c3139be0bf584a3a584a57216dfa18930d769566e6f42b2c855ae89"
+checksum = "8f1b329afdf6ab11624cf3710d3ddaf234a0fcf68dc85d12f089f0e7550dff8c"
 dependencies = [
  "log",
  "memoffset",
@@ -401,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "patina_adv_logger"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2021f9b6ac77631b5ded17cdc9b86bc36d0cb53c988221d0e02c67a932cd2445"
+checksum = "8c51e68c7141f90ee181f5356bab5eabc8e659a2e88fa79c5043db0d9d3b0f06"
 dependencies = [
  "log",
  "mu_rust_helpers",
@@ -417,9 +408,9 @@ dependencies = [
 
 [[package]]
 name = "patina_debugger"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039063d2a25e058393df325a0f52ee766a60299856136d65eb9f6eb21d6d3b0a"
+checksum = "c7fed76ce8cabe237ab96d91f2886e11b9846fa3282161ab7b11033857892315"
 dependencies = [
  "bitfield-struct",
  "cfg-if",
@@ -434,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "patina_dxe_core"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a866acc553bf863a28a7524f7a9d3141643441179f0d37caf7e5071d06b36b4"
+checksum = "0a1544fbd61b24e05972196c0d57481155c8b32f3e6cbd89ce597d6f9d9196dd"
 dependencies = [
  "arm-gic",
  "bitfield-struct",
@@ -465,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c60cf63519fde3705eb67cc7378596de0ddd6132d8d07b2cee5c57229e505f6"
+checksum = "54716e17261459f356d5684ffdcd45d22b150609026c0f7955694925bb34db01"
 dependencies = [
  "log",
  "patina",
@@ -476,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs_extractors"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d10bd1120e350f1b610a3181c16445eaae97994bed4156409ade6a03a43250"
+checksum = "c73915aaf1c8a8a6d84e71ee26818ba98e625985f171f5bf02a7ceea6dc3fc4b"
 dependencies = [
  "alloc-no-stdlib",
  "brotli-decompressor",
@@ -492,18 +483,18 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_collections"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c81c7e3077ccbf43d0adeabb8e2404be1e2bc288ccf1818c6ab99e9ab7626a"
+checksum = "1852d7396a584457d0869dc1526aaa0d7f5b7e3da45929617b61be25bb876754"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "patina_internal_cpu"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bea5c7fde5b398b01d3b20cd41482461dcb1f9f7fad2a3b1435cca8d6c4f604e"
+checksum = "c8b5c7c7584284fa204b3bd7a18bfd8048e9cc12a1d4748635352395b14cbd38"
 dependencies = [
  "arm-gic",
  "cfg-if",
@@ -519,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_depex"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64227e44b6035646744dc3de80b004b86f7bf8347e80425ba8facf96b9ef809f"
+checksum = "81ab599be33fab130f363a928c33593d2bfedb2344da2625ab308a0b9d69917c"
 dependencies = [
  "log",
  "r-efi",
@@ -540,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "patina_macro"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a74965ff8c18ef45a3dad49fba8fb84e58427200b28375783799a4759e8f3f4"
+checksum = "5ae47374d5c0c352ec0105d731c4c13bb47d35e473c5beff0339f1ff35fd3c45"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -552,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "patina_mm"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5bedaa627c20bf1d7eb2d11ce202eadf4a938ec50ac3d6ef9f24604c3ff594"
+checksum = "68efdb72b19325746fab85038a1f2487705dfd675b078eec68f114f89939352d"
 dependencies = [
  "cfg-if",
  "log",
@@ -588,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "patina_performance"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643c7833e32a52250773413637731e4c73e8f386fd3ece09f1b0f0e79b264f4a"
+checksum = "d19ee910859e3b40bb4df081ebbb2f0599aed3ec838ab290ac84cc5bd9d7f466"
 dependencies = [
  "log",
  "mu_rust_helpers",
@@ -604,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "patina_samples"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c5a654a165a8147211e4fbd35d75bb39483db9009d1976e701cb1bcf23a8866"
+checksum = "6c6a952052ae6012f21eb9bb4b2aca9a8176b91514b5a05c76da91474bee4a60"
 dependencies = [
  "log",
  "patina",
@@ -616,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "patina_smbios"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4552af3b960fd14e83d3d7aac78b197736e45de4168b2869c4d98b674ae6165b"
+checksum = "ebe253c6f49a4b25413b956aa0750fda93416d34ef09d66654f6f2ad8372c1d8"
 dependencies = [
  "bitfield-struct",
  "log",
@@ -632,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "patina_stacktrace"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b77dcd920470e59372f09d40186ea7040930ef62211cd9f5bdeb0e3c59dc7db"
+checksum = "6c08e90b9d3553745afc4b47f83d380c1dfdca877b4722315a530616b2dc4d37"
 dependencies = [
  "cfg-if",
  "log",
@@ -642,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "patina_test"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ceadc3ce5f3f45faa99f1a305f7659edeef018199d012d83ea3f9c87e327ba"
+checksum = "f4d274ff15945708cd716f44199d8bff62109b77501a50014a6fc31749e16e7f"
 dependencies = [
  "linkme",
  "log",
@@ -683,7 +674,7 @@ checksum = "8189cbf0422ac15d7d544ed5f331fbe4e5b9da88133568fd359083b186a547f3"
 
 [[package]]
 name = "qemu_dxe_core"
-version = "3.0.8"
+version = "3.0.9"
 dependencies = [
  "log",
  "patina",
@@ -830,9 +821,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -867,12 +858,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -882,15 +872,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
@@ -921,9 +911,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 
 [[package]]
 name = "volatile"
@@ -966,18 +956,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qemu_dxe_core"
-version = "3.0.8"
+version = "3.0.9"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Description

Updates to the latest patina patch release.

Release changes:

https://github.com/OpenDevicePartnership/patina/releases/tag/patina-v22.0.1

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- QEMU Q35 & ArmVirt boot to EFI shell

## Integration Instructions

- N/A