### PR TITLE
v3.0.10: Update to patina v22.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,14 +19,26 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "arm-gic"
-version = "0.7.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c044ecf8760dd8ee5aa92c49cf7534942d289fb1f0247af92b5fbab8ab18a912"
+checksum = "84372c6068152f635a04870779f0fa0d1b0273dd09dbe1c6747688693d061f06"
 dependencies = [
+ "arm-sysregs",
  "bitflags 2.13.0",
  "safe-mmio",
  "thiserror",
  "zerocopy",
+]
+
+[[package]]
+name = "arm-sysregs"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27f98a99c7c6da5d54aa4d6e54504956aade8cdb0de9cd9a2363eb66b1d659a9"
+dependencies = [
+ "bitflags 2.13.0",
+ "num_enum",
+ "paste",
 ]
 
 [[package]]
@@ -53,6 +65,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitfield-struct"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca6739863c590881f038d033a146c51ddae239186a4327014839fd864f44ed5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,9 +89,9 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -211,15 +234,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
-
-[[package]]
 name = "linked_list_allocator"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "managed"
@@ -280,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "mu_rust_helpers"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f0939baed11fd68187c2fd292ee166944cdd8472bc8cf261b08e3cbd568d9d6"
+checksum = "19cef5cf6070922037fb68c8e4ff71d0e6c8e7ea4e805ffc7e78bff146913236"
 dependencies = [
  "mu_uefi_decompress",
  "mu_uefi_guid",
@@ -291,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "mu_uefi_decompress"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5592026864b59cc927a2f42ad2721b9820271d6f70ba2e20a796621eb688389f"
+checksum = "f9da042c7e29a7e6284f60c0ba9bc32591e2e826f2b5d556e613477fcd0f699b"
 dependencies = [
  "bitvec",
  "log",
@@ -301,19 +315,19 @@ dependencies = [
 
 [[package]]
 name = "mu_uefi_guid"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "392e8c601a9cc36a519c61063a3250e55a3b049a85ee314e49b8a1ad09ff70c3"
+checksum = "50865ae22956d8891b8fe263d0ea14d6f67b1a6195bd59b4b745ed383c72bbbd"
 dependencies = [
- "r-efi",
+ "r-efi 7.0.0",
  "uuid",
 ]
 
 [[package]]
 name = "mu_uefi_perf_timer"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4819bbf728631dd84bc2511c5c3551687db00830998e4937a0ff7af33a591b15"
+checksum = "5ae7d76a95a78374ad835d949b0c33a4a82b587982946047c3f4040bfe9f08cb"
 dependencies = [
  "aarch64-cpu",
  "log",
@@ -335,10 +349,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
@@ -348,10 +389,11 @@ checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "patina"
-version = "22.0.1"
+version = "22.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8e4a036f833831dbc6ccf63e043bc748d96d9b705babed625d8f7a28894c4b"
+checksum = "5dd192d95a5583e9cd8b70d23c084489ca928f400578a9f71c54a4bdc6160724"
 dependencies = [
+ "bitvec",
  "cfg-if",
  "compile-time",
  "fallible-streaming-iterator",
@@ -360,13 +402,12 @@ dependencies = [
  "indoc",
  "linkme",
  "log",
- "mu_rust_helpers",
  "num-traits",
  "patina_macro",
- "r-efi",
+ "r-efi 6.0.0",
  "safe-mmio",
  "scroll",
- "spin",
+ "spin 0.12.1",
  "uart_16550",
  "uuid",
  "zerocopy",
@@ -383,9 +424,9 @@ dependencies = [
  "memoffset",
  "patina",
  "patina_test",
- "r-efi",
+ "r-efi 6.0.0",
  "scroll",
- "spin",
+ "spin 0.9.8",
  "zerocopy",
  "zerocopy-derive",
 ]
@@ -400,19 +441,19 @@ dependencies = [
  "mu_rust_helpers",
  "patina",
  "patina_test",
- "r-efi",
- "spin",
+ "r-efi 6.0.0",
+ "spin 0.9.8",
  "zerocopy",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "patina_debugger"
-version = "22.0.1"
+version = "22.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fed76ce8cabe237ab96d91f2886e11b9846fa3282161ab7b11033857892315"
+checksum = "4fcdef98ab1680c0d9b03b4fa56ed1d754a1b1007001607a14d60a5998c6c258"
 dependencies = [
- "bitfield-struct",
+ "bitfield-struct 0.13.0",
  "cfg-if",
  "gdbstub",
  "log",
@@ -420,25 +461,23 @@ dependencies = [
  "patina_internal_cpu",
  "patina_mtrr",
  "patina_paging",
- "spin",
+ "spin 0.12.1",
 ]
 
 [[package]]
 name = "patina_dxe_core"
-version = "22.0.1"
+version = "22.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1544fbd61b24e05972196c0d57481155c8b32f3e6cbd89ce597d6f9d9196dd"
+checksum = "80d38eefea7e23b4a5d4f86e46bd562ec538c55fe6021dedb15757b9923a35a9"
 dependencies = [
  "arm-gic",
- "bitfield-struct",
+ "bitfield-struct 0.13.0",
  "cfg-if",
  "corosensei",
  "crc32fast",
  "goblin",
- "lazy_static",
  "linked_list_allocator",
  "log",
- "mu_rust_helpers",
  "patina",
  "patina_debugger",
  "patina_ffs",
@@ -448,21 +487,21 @@ dependencies = [
  "patina_paging",
  "patina_performance",
  "patina_test",
- "r-efi",
+ "r-efi 6.0.0",
  "scroll",
- "spin",
+ "spin 0.12.1",
  "uuid",
 ]
 
 [[package]]
 name = "patina_ffs"
-version = "22.0.1"
+version = "22.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54716e17261459f356d5684ffdcd45d22b150609026c0f7955694925bb34db01"
+checksum = "494ee34683609706628c7925e361f150da69bac8d17a9e80ac723a28ae7f1686"
 dependencies = [
  "log",
  "patina",
- "r-efi",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -478,44 +517,43 @@ dependencies = [
  "patina",
  "patina_ffs",
  "patina_lzma_rs",
- "r-efi",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
 name = "patina_internal_collections"
-version = "22.0.1"
+version = "22.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1852d7396a584457d0869dc1526aaa0d7f5b7e3da45929617b61be25bb876754"
+checksum = "9ebe53b3619aa0b7d4a4699da263d47064f12d1567f484bfedcfb85428224530"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "patina_internal_cpu"
-version = "22.0.1"
+version = "22.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8b5c7c7584284fa204b3bd7a18bfd8048e9cc12a1d4748635352395b14cbd38"
+checksum = "198460c8d8b988fd5f6d14ef7f5ecc7b581943c4bacc1de4b3e17c583a07f3bc"
 dependencies = [
  "arm-gic",
  "cfg-if",
- "lazy_static",
  "log",
  "patina",
  "patina_mtrr",
  "patina_paging",
  "patina_stacktrace",
- "r-efi",
- "spin",
+ "r-efi 6.0.0",
+ "spin 0.12.1",
 ]
 
 [[package]]
 name = "patina_internal_depex"
-version = "22.0.1"
+version = "22.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ab599be33fab130f363a928c33593d2bfedb2344da2625ab308a0b9d69917c"
+checksum = "5c648fb89fe58b9e514d02d9d2b2f77381d626360921c3f52519b4b5cc0ea53d"
 dependencies = [
  "log",
- "r-efi",
+ "r-efi 6.0.0",
  "uuid",
 ]
 
@@ -531,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "patina_macro"
-version = "22.0.1"
+version = "22.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ae47374d5c0c352ec0105d731c4c13bb47d35e473c5beff0339f1ff35fd3c45"
+checksum = "d6b533f41a4294a818f7e1c0f19bb63eee39a38e45e0424381368d96fe294a02"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -543,14 +581,14 @@ dependencies = [
 
 [[package]]
 name = "patina_mm"
-version = "22.0.1"
+version = "22.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68efdb72b19325746fab85038a1f2487705dfd675b078eec68f114f89939352d"
+checksum = "d7add529a3be1d90badccf7ae09dfb7c7a57b93559d4d1bfda383dc0b8acbd2d"
 dependencies = [
  "cfg-if",
  "log",
  "patina",
- "r-efi",
+ "r-efi 6.0.0",
  "zerocopy",
  "zerocopy-derive",
 ]
@@ -561,17 +599,17 @@ version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfc41f2f46a1b1cf85cec0176ed92e776633dafd2f417d36f75025268b4abba8"
 dependencies = [
- "bitfield-struct",
+ "bitfield-struct 0.12.1",
  "cfg-if",
 ]
 
 [[package]]
 name = "patina_paging"
-version = "11.0.4"
+version = "11.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5265104f7091071dea0506fe9e733cf347cc49c3ae49eaf0067508297e0e296b"
+checksum = "cfc6c615cceb14ff91522c846c0894aebe6d4b3b5a569552b914e68730be7bd1"
 dependencies = [
- "bitfield-struct",
+ "bitfield-struct 0.13.0",
  "bitflags 2.13.0",
  "cfg-if",
  "log",
@@ -579,15 +617,14 @@ dependencies = [
 
 [[package]]
 name = "patina_performance"
-version = "22.0.1"
+version = "22.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19ee910859e3b40bb4df081ebbb2f0599aed3ec838ab290ac84cc5bd9d7f466"
+checksum = "b5fa12135c2fc6c05874da7bf4f2f78b2e787774ec1da4ac3554d15c73f6d5ed"
 dependencies = [
  "log",
- "mu_rust_helpers",
  "patina",
  "patina_mm",
- "r-efi",
+ "r-efi 6.0.0",
  "uuid",
  "zerocopy",
  "zerocopy-derive",
@@ -611,21 +648,21 @@ version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe253c6f49a4b25413b956aa0750fda93416d34ef09d66654f6f2ad8372c1d8"
 dependencies = [
- "bitfield-struct",
+ "bitfield-struct 0.12.1",
  "log",
  "patina",
  "patina_macro",
- "r-efi",
- "spin",
+ "r-efi 6.0.0",
+ "spin 0.9.8",
  "zerocopy",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "patina_stacktrace"
-version = "22.0.1"
+version = "22.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c08e90b9d3553745afc4b47f83d380c1dfdca877b4722315a530616b2dc4d37"
+checksum = "3694b36c7c519cd597b3a79374e67f569b2240039c9d1213bf3a80357925ad90"
 dependencies = [
  "cfg-if",
  "log",
@@ -633,16 +670,16 @@ dependencies = [
 
 [[package]]
 name = "patina_test"
-version = "22.0.1"
+version = "22.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4d274ff15945708cd716f44199d8bff62109b77501a50014a6fc31749e16e7f"
+checksum = "3b224a0303d83cdfafc5a1a66615985e9cc60dd62c1c15bed801d419fd23c600"
 dependencies = [
  "linkme",
  "log",
  "patina",
  "patina_macro",
- "r-efi",
- "spin",
+ "r-efi 6.0.0",
+ "spin 0.12.1",
 ]
 
 [[package]]
@@ -690,16 +727,16 @@ dependencies = [
  "patina_stacktrace",
  "patina_test",
  "qemu-exit",
- "r-efi",
+ "r-efi 6.0.0",
  "x86_64",
  "zerocopy",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -709,6 +746,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "r-efi"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1b35d612599fa2eed43b064164175ebe98c88de47c8cc6cc6c50d6502aa6abe"
 
 [[package]]
 name = "radium"
@@ -742,9 +785,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "safe-mmio"
-version = "0.2.7"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a69f884a1511aa811aa94e04559414a66b18ca63f50f84ca31e304f38bad0d"
+checksum = "4813ee49326057f105d6d8ca3d8f9265095f26aa7b42094e487028403a594f4c"
 dependencies = [
  "zerocopy",
 ]
@@ -811,6 +854,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5231412d905519dca6a5deb0327d407be68d6c941feec004533401d3a0a715"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spinning_top"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
  "num-conv",
@@ -878,9 +930,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qemu_dxe_core"
-version = "3.0.9"
+version = "3.0.10"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Description

Updates Patina a underlying dependencies for Patina release. 22.0.2.

https://github.com/OpenDevicePartnership/patina/releases/tag/patina-v22.0.2

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Boot to shell on armvirt and q35

## Integration Instructions

N/A