### PR TITLE
v3.1.2: Update to patina 22.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,9 +313,9 @@ checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "patina"
-version = "22.2.0"
+version = "22.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3947c7464ca0880b1630d8142cdb716fb461d5e6c908bf4a85a2b1cc91ae3d5b"
+checksum = "94b84f9588e257ebd77b1a86df01b311efc82de1220bb2ce851060c9dda17d03"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -340,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "patina_acpi"
-version = "22.2.0"
+version = "22.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f77ec0ce985098f9c039cb9f5c8932f67aaaaa319ba5279b70039c12475c28d3"
+checksum = "f41f47c3037ac67d693c4f8b550330691816dac74e6cdcef0b51e13d63caf40c"
 dependencies = [
  "log",
  "memoffset",
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "patina_adv_logger"
-version = "22.2.0"
+version = "22.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b9833cf2c5da795c38f2de039f10db3e58ee6b1f9fcef2fe172f5f51e582a1"
+checksum = "03afe609f923b3c8c4cc7ae67ccbf0db229af3b7fd0d961877b5da4f7336b8e5"
 dependencies = [
  "log",
  "patina",
@@ -372,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "patina_debugger"
-version = "22.2.0"
+version = "22.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86327121c7c7f4dd7531588751b2fcf69cabd420ff16f3585cd0974e0683140"
+checksum = "9dee6fccb019150be264e692ce5349153892bc1bca6b1f2c81df151903cb869b"
 dependencies = [
  "bitfield-struct",
  "cfg-if",
@@ -389,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "patina_dxe_core"
-version = "22.2.0"
+version = "22.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59824a2cd27eda98fcfab179e655fc3864f3c869ac3c6d099267dbf924c84353"
+checksum = "08cbcbf8d08f2bddcdcf3340dd36fbdf35c63391ef59fd195897d1216dbb4550"
 dependencies = [
  "arm-gic",
  "bitfield-struct",
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs"
-version = "22.2.0"
+version = "22.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7620276248df71bfb3d2b5c8ae2c756491e96fcdbf066030730591903bcd6899"
+checksum = "2c86b5949808dee9a83ac11b80e7563d999dc6fe76506a4a8662b97a69ec8cdb"
 dependencies = [
  "log",
  "patina",
@@ -428,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs_extractors"
-version = "22.2.0"
+version = "22.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f2a25053ee9579330552c5dca16ca6ac8fab3e7557b25518c3ec08bf74b4d85"
+checksum = "5a13a594192f90edb113693520bd95d4b5edf903ccb4de3260d5ae8d55ecde0f"
 dependencies = [
  "alloc-no-stdlib",
  "brotli-decompressor",
@@ -444,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_core"
-version = "22.2.0"
+version = "22.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025f2a23b28180ea3c2b3bd0a5b5c795c1bdf9d0a4fc7ff29ab253961121bf88"
+checksum = "46507e99977fb333fdc02789c2dc2afb335401f0b75227a2e28242b6ef2d2f63"
 dependencies = [
  "log",
  "r-efi",
@@ -455,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_cpu"
-version = "22.2.0"
+version = "22.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83b3dd6bbbb39661c8c17f92e7a38d93523b154a145f6a221b189a3af4766e6"
+checksum = "448dc731fea02a90c415b74a9bda0cd0c5d8388c2f7dd6572f9aeea3b938f36b"
 dependencies = [
  "arm-gic",
  "cfg-if",
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "patina_macro"
-version = "22.2.0"
+version = "22.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a709035f2a693d4e7e4916fb4cecedc7cb022ec2e2bfd25c24777fda81c2f6ba"
+checksum = "e28ff6a69110bb33a1f590a00d6160b1cb145b451d1410e57eec00f2c325c52c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -484,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "patina_mm"
-version = "22.2.0"
+version = "22.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b5b482ced5f039bec3aae0dba28fceea655a6c4ea4a5b15e31c36f733df2cc"
+checksum = "108ac8af498dafb836b224ea56e5362cde99005abb76d605f9a7bf53cc7a91e6"
 dependencies = [
  "cfg-if",
  "log",
@@ -520,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "patina_performance"
-version = "22.2.0"
+version = "22.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6805a1fa3f016aa7943bfa103ad010e4736eeac49d050d66437b3cbd68e0ba2f"
+checksum = "562c05041e90a39f99f4f6792b40c338d37dcd83f313fb0d562135a4b3ce548f"
 dependencies = [
  "log",
  "patina",
@@ -535,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "patina_samples"
-version = "22.2.0"
+version = "22.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31fcbf926c51b8a9457b66320a4aa1fe8606bbf47fc7282fb85b4a5ec46d96ba"
+checksum = "87f0f7765acd65739837f4364c4e871f147d23b950d7c2597fef8fdedb227aa7"
 dependencies = [
  "log",
  "patina",
@@ -547,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "patina_smbios"
-version = "22.2.0"
+version = "22.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8e2fbd500ec5572a507f7e4bf029c1c3e08e3a11ba6e1d078520b55a9d3304"
+checksum = "c695728ba6261b86269504061e4613e9ff8963c7fed3c6625aa84d46a558642e"
 dependencies = [
  "bitfield-struct",
  "log",
@@ -563,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "patina_stacktrace"
-version = "22.2.0"
+version = "22.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de1aa82cc1c508714acbe06a3b9572dd1affa2b5dc0dc779362a3caac3b4d6c6"
+checksum = "0b68b4585f0f5dfffbdafd45194401f7f93ce2fde433d2330c31f3710b953699"
 dependencies = [
  "cfg-if",
  "log",
@@ -573,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "patina_test"
-version = "22.2.0"
+version = "22.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f41cd7f2187753f34797c85e1bb7ffe1d1ce47c598473ee30d495becda682d5f"
+checksum = "29a83ab805a4b9816814512f8d2bd5a46c262b4e6eb77506be19e952adfdbe83"
 dependencies = [
  "linkme",
  "log",
@@ -614,7 +614,7 @@ checksum = "8189cbf0422ac15d7d544ed5f331fbe4e5b9da88133568fd359083b186a547f3"
 
 [[package]]
 name = "qemu_dxe_core"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "log",
  "patina",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qemu_dxe_core"
-version = "3.1.1"
+version = "3.1.2"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Description

Updates to the latest patina release. See the release notes for more details about changes in the release:

https://github.com/OpenDevicePartnership/patina/releases/tag/patina-v22.2.1

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
- QEMU ArmVirt & Q35 boot to EFI shell

## Integration Instructions

- No expected changes in QEMU platforms code apart from picking up this release
