### PR TITLE
Remove `doc` feature in favor of `doc` cfg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,6 @@ v1_resource_descriptor_support = [
 ]
 x64 = ["x86_64"]
 aarch64 = []
-doc = []
 std = []
 build_debugger = ["patina_dxe_core/debugger_reload"]
 enable_debugger = ["build_debugger"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -490,12 +490,12 @@ run_task = "patch"
 [tasks.doc]
 description = "Builds all rust documentation in the workspace. Example `cargo make doc`"
 command = "cargo"
-args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--features", "doc", "--no-deps"]
+args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--no-deps"]
 
 [tasks.doc-open]
 description = "Builds all rust documentation in the workspace and opens the documentation Example `cargo make doc-open`"
 command = "cargo"
-args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--features", "doc", "--open"]
+args = ["doc", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "--open"]
 
 [tasks.clippy]
 description = "Run cargo clippy for the host target and both UEFI cross-compilation targets."


### PR DESCRIPTION
## Description

Sync'd files are also updated via this PR: https://github.com/OpenDevicePartnership/patina-devops/pull/183

ref: [doc cfg functionality](https://doc.rust-lang.org/rustdoc/advanced-features.html#cfgdoc-documenting-platform-specific-or-feature-specific-information)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
