### PR TITLE
Ingest Patina version 23.0.0 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,9 +313,9 @@ checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "patina"
-version = "22.2.4"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d417a3eb5a14bdc37f7cd6abe09b2e0e0983a90888892d12d6eab4f430f993bb"
+checksum = "344cdfdd7a8b241ebc10914b12298fe42dfabf9c14612319bee47e7603fbcb6d"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -339,29 +339,27 @@ dependencies = [
 
 [[package]]
 name = "patina_acpi"
-version = "22.2.4"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd478390dd811fa9a4fe9b41bf031e026720d056599588589ffb865275c8de5f"
+checksum = "c04af5a5d6acf8f3252d2d34c58f25c20b93ad6033729f1986376e8a5dda0a9f"
 dependencies = [
  "log",
  "memoffset",
  "patina",
  "patina_test",
- "r-efi",
  "zerocopy",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "patina_adv_logger"
-version = "22.2.4"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58413eeb36523bc1807e0c0c8948ec6ab9f042211b59ea7befc14361118d1a9b"
+checksum = "d9198c6f28c668d2a28e728d363e95f188f1cc78b5d329ed2c2ca13b5ed85204"
 dependencies = [
  "log",
  "patina",
  "patina_test",
- "r-efi",
  "spin",
  "zerocopy",
  "zerocopy-derive",
@@ -369,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "patina_debugger"
-version = "22.2.4"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126f5cebd3ad0ba5f1ba203edda0871363492814b457263086f8c44a0442fc18"
+checksum = "05180d391b968ae71418dd63302721506ad4c72a364181cd73166e2e75346991"
 dependencies = [
  "bitfield-struct",
  "cfg-if",
@@ -386,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "patina_dxe_core"
-version = "22.2.4"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3881119393f987ac7f62535c03aa95558fa4a3d3565e5fe459ecf16d6820eb52"
+checksum = "e518bc972a9bb50a05807da675385bafecd3653172a6437f1a657c09657a0132"
 dependencies = [
  "arm-gic",
  "bitfield-struct",
@@ -405,7 +403,6 @@ dependencies = [
  "patina_internal_cpu",
  "patina_paging",
  "patina_test",
- "r-efi",
  "scroll",
  "spin",
  "uuid",
@@ -413,20 +410,19 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs"
-version = "22.2.4"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7db4521bc73ac871f130d5b0b71cde1a11aec1edc1320664aa2a642df6f766d"
+checksum = "f2b80cf12725e1bfe6cf385f145bb66099b4696e7ada48fd519a8000b191db61"
 dependencies = [
  "log",
  "patina",
- "r-efi",
 ]
 
 [[package]]
 name = "patina_ffs_extractors"
-version = "22.2.4"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e26694e0f42817061c0954320d88982f5b8b2a6427c79394cdf6326fd6222d"
+checksum = "2b398fc0c61dc534f6850082ac85d44a6af583eb57378c36020e9251fe048ff3"
 dependencies = [
  "alloc-no-stdlib",
  "brotli-decompressor",
@@ -438,20 +434,20 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_core"
-version = "22.2.4"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030918a99964f3944082826fab2394a38b63e4b969038f964ce08bb1a20ba6f6"
+checksum = "9065423485eb3497409de1c6e7e6a78a69c35481e0c0d7d03a7b590d55bd4236"
 dependencies = [
  "log",
- "r-efi",
+ "patina",
  "uuid",
 ]
 
 [[package]]
 name = "patina_internal_cpu"
-version = "22.2.4"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b8b672c660fbfe2075749a9310f2a2c281c155a151dd6024c04ca9ff4b3ac21"
+checksum = "009b7d6f26db18f56c8a667dcef013b1d7cf4978587406fa9d6970561797dc9c"
 dependencies = [
  "arm-gic",
  "cfg-if",
@@ -460,32 +456,30 @@ dependencies = [
  "patina_mtrr",
  "patina_paging",
  "patina_stacktrace",
- "r-efi",
  "spin",
 ]
 
 [[package]]
 name = "patina_macro"
-version = "22.2.4"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de261b0f456338c1f0e2af5e03c16d5d248c1c6a972150b5a7aedd301503b62"
+checksum = "43f848fa43b647dd9712fa971b4328f74459ff355362c3c95b025d9b54399ec5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
  "uuid",
 ]
 
 [[package]]
 name = "patina_mm"
-version = "22.2.4"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b06e2b9a27d67f3da61a7efc11b6771d9f556ca3e7d3597ea88c74533573bf"
+checksum = "35d4efc2d5d750c11e369bcc1260e4005957aeb7cc77d402077c095a5edc77fe"
 dependencies = [
  "cfg-if",
  "log",
  "patina",
- "r-efi",
  "zerocopy",
  "zerocopy-derive",
 ]
@@ -514,23 +508,22 @@ dependencies = [
 
 [[package]]
 name = "patina_performance"
-version = "22.2.4"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5523c23a1f5a68c517b1fc5dc675431408389fb1e1243bc0de1695a3319958c"
+checksum = "024ca5d74143dcd6a9683ac25c4eada052cbac8e3f3dbe1b640a29a7d06ac778"
 dependencies = [
  "log",
  "patina",
  "patina_mm",
- "r-efi",
  "zerocopy",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "patina_samples"
-version = "22.2.4"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9bc235acb0ad6f7e7c8a95656859a188fd715988b313728c2411ef778aaf06a"
+checksum = "d27a28f09d0cd5baeaf9e6bd27f504158574564c3a8348ee7d0f3fd2257f0f27"
 dependencies = [
  "log",
  "patina",
@@ -540,24 +533,23 @@ dependencies = [
 
 [[package]]
 name = "patina_smbios"
-version = "22.2.4"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b81d95c067f371d73daffc055039851d0dc826a0e58ab1064fea750769f65e"
+checksum = "b2aff26a11e7750eb5d92b2f0046ffc4ceb29dbf28626f8a5a738725e666112e"
 dependencies = [
  "bitfield-struct",
  "log",
  "patina",
  "patina_macro",
- "r-efi",
  "zerocopy",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "patina_stacktrace"
-version = "22.2.4"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42fe02343bce10c8c95b70d1e1b5b1bb10646d4dca9076d9183bdc9abb3106c8"
+checksum = "9db93f10f391c13b1b88f57e1ce8ae50d1dc6579ca1efc794882d2c144445dd2"
 dependencies = [
  "cfg-if",
  "log",
@@ -565,15 +557,14 @@ dependencies = [
 
 [[package]]
 name = "patina_test"
-version = "22.2.4"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bc1e2aae3a6537cb622626d249e16d63dfbcedfbc0635b9fd7352dca79880b"
+checksum = "534936d7ac4e8c5a95914b4f88d00f77c4437dd27e0dbc0483b38c4db525cbf9"
 dependencies = [
  "linkme",
  "log",
  "patina",
  "patina_macro",
- "r-efi",
  "spin",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,18 +26,18 @@ path = "src/lib.rs"
 [dependencies]
 
 # Patina dependencies
-patina = { version = "22" }
-patina_acpi = { version = "22" }
-patina_adv_logger = { version = "22" }
-patina_debugger = { version = "22" }
-patina_dxe_core = { version = "22" }
-patina_ffs_extractors = { version = "22" }
-patina_mm = { version = "22" }
-patina_performance = { version = "22" }
-patina_samples = { version = "22" }
-patina_smbios = { version = "22" }
-patina_stacktrace = { version = "22" }
-patina_test = { version = "22", features = ["test-runner"] }
+patina = { version = "23" }
+patina_acpi = { version = "23" }
+patina_adv_logger = { version = "23" }
+patina_debugger = { version = "23" }
+patina_dxe_core = { version = "23" }
+patina_ffs_extractors = { version = "23" }
+patina_mm = { version = "23" }
+patina_performance = { version = "23" }
+patina_samples = { version = "23" }
+patina_smbios = { version = "23" }
+patina_stacktrace = { version = "23" }
+patina_test = { version = "23", features = ["test-runner"] }
 
 # Other dependencies
 log = { version = "^0.4", default-features = false, features = [

--- a/bin/arm_virt_dxe_core.rs
+++ b/bin/arm_virt_dxe_core.rs
@@ -12,8 +12,8 @@
 
 use core::{ffi::c_void, panic::PanicInfo};
 #[cfg(feature = "build_debugger")]
-use patina::serial::virtio::VirtioSerial;
-use patina::{log::Format, serial::uart::UartPl011};
+use patina::peripheral::serial::virtio::VirtioSerial;
+use patina::{debug::log::Format, performance::config::PerformanceConfig, peripheral::serial::uart::UartPl011};
 use patina_adv_logger::{
     component::AdvancedLoggerComponent,
     logger::{AdvancedLogger, TargetFilter},
@@ -47,7 +47,8 @@ static LOGGER: AdvancedLogger<UartPl011> = AdvancedLogger::new(
         TargetFilter { target: "efi_memory_map", log_level: log::LevelFilter::Off, hw_filter_override: None },
     ],
     log::LevelFilter::Info,
-    UartPl011::new(PL011_UART_BASE),
+    // SAFETY: PL011_UART_BASE is the valid PL011 UART MMIO base owned by this logger.
+    unsafe { UartPl011::new(PL011_UART_BASE) },
 );
 
 #[cfg(feature = "enable_debugger")]
@@ -99,12 +100,7 @@ impl ComponentInfo for ArmVirt {
             #[cfg(feature = "exit_on_patina_test_failure")]
             qemu_fail();
         }));
-        add.component(patina_performance::component::Performance::new().with_measurements(
-            patina::performance::Measurement::DriverBindingStart     // Adds driver binding start measurements.
-               | patina::performance::Measurement::DriverBindingStop // Adds driver binding stop measurements.
-               | patina::performance::Measurement::LoadImage         // Adds load image measurements.
-               | patina::performance::Measurement::StartImage, // Adds start image measurements.
-        ));
+        add.component(patina_performance::component::Performance::new());
         add.component(patina_acpi::component::AcpiComponent::default());
     }
 
@@ -116,6 +112,12 @@ impl PlatformInfo for ArmVirt {
     type MemoryInfo = Self;
     type ComponentInfo = Self;
     type Extractor = CompositeSectionExtractor;
+
+    const DEFAULT_PERFORMANCE_CONFIG: PerformanceConfig = PerformanceConfig::new()
+        .with_measurement(patina::performance::Measurement::DriverBindingStart)
+        .with_measurement(patina::performance::Measurement::DriverBindingStop)
+        .with_measurement(patina::performance::Measurement::LoadImage)
+        .with_measurement(patina::performance::Measurement::StartImage);
 }
 
 static CORE: Core<ArmVirt> = Core::new(CompositeSectionExtractor::new());

--- a/bin/ovmf_dxe_core.rs
+++ b/bin/ovmf_dxe_core.rs
@@ -44,7 +44,8 @@ static LOGGER: SerialLogger<Uart16550> = SerialLogger::new(
         ("goblin", log::LevelFilter::Off),
     ],
     log::LevelFilter::Info,
-    Uart16550::Io { base: 0x402 },
+    // SAFETY: 0x402 is the QEMU OVMF debug-console I/O port owned by this logger.
+    unsafe { Uart16550::new_io(0x402) },
 );
 
 const PM_TIMER_PORT: u16 = 0x608;
@@ -52,9 +53,10 @@ const _ENABLE_DEBUGGER: bool = cfg!(feature = "enable_debugger");
 
 #[cfg(feature = "build_debugger")]
 static DEBUGGER: patina_debugger::PatinaDebugger<Uart16550> =
-    patina_debugger::PatinaDebugger::new(Uart16550::Io { base: 0x3F8 })
-        .with_force_enable(_ENABLE_DEBUGGER)
-        .with_log_policy(patina_debugger::DebuggerLoggingPolicy::FullLogging);
+    // SAFETY: 0x3F8 is the standard COM1 I/O port owned by the debugger.
+    patina_debugger::PatinaDebugger::new(unsafe { Uart16550::new_io(0x3F8) })
+            .with_force_enable(_ENABLE_DEBUGGER)
+            .with_log_policy(patina_debugger::DebuggerLoggingPolicy::FullLogging);
 
 struct Ovmf;
 

--- a/bin/ovmf_dxe_core.rs
+++ b/bin/ovmf_dxe_core.rs
@@ -12,8 +12,8 @@
 
 use core::{ffi::c_void, panic::PanicInfo};
 use patina::{
-    log::{Format, SerialLogger},
-    serial::uart::Uart16550,
+    debug::log::{Format, SerialLogger},
+    peripheral::serial::uart::Uart16550,
 };
 use patina_dxe_core::*;
 use patina_ffs_extractors::CompositeSectionExtractor;

--- a/bin/q35_dxe_core.rs
+++ b/bin/q35_dxe_core.rs
@@ -11,7 +11,7 @@
 #![no_main]
 
 use core::{ffi::c_void, panic::PanicInfo};
-use patina::{log::Format, serial::uart::Uart16550};
+use patina::{debug::log::Format, performance::config::PerformanceConfig, peripheral::serial::uart::Uart16550};
 use patina_adv_logger::{
     component::AdvancedLoggerComponent,
     logger::{AdvancedLogger, TargetFilter},
@@ -54,7 +54,8 @@ static LOGGER: AdvancedLogger<Uart16550> = AdvancedLogger::new(
         TargetFilter { target: "patina_performance", log_level: log::LevelFilter::Off, hw_filter_override: None },
     ],
     log::LevelFilter::Info,
-    Uart16550::Io { base: 0x402 },
+    // SAFETY: 0x402 is the QEMU Q35 debug-console I/O port owned by this logger.
+    unsafe { Uart16550::new_io(0x402) },
 );
 
 #[cfg(feature = "enable_debugger")]
@@ -64,9 +65,10 @@ const _ENABLE_DEBUGGER: bool = false;
 
 #[cfg(feature = "build_debugger")]
 static DEBUGGER: patina_debugger::PatinaDebugger<Uart16550> =
-    patina_debugger::PatinaDebugger::new(Uart16550::Io { base: 0x3F8 })
-        .with_force_enable(_ENABLE_DEBUGGER)
-        .with_log_policy(patina_debugger::DebuggerLoggingPolicy::FullLogging);
+    // SAFETY: 0x3F8 is the standard COM1 I/O port owned by the debugger.
+    patina_debugger::PatinaDebugger::new(unsafe { Uart16550::new_io(0x3F8) })
+            .with_force_enable(_ENABLE_DEBUGGER)
+            .with_log_policy(patina_debugger::DebuggerLoggingPolicy::FullLogging);
 
 struct Q35;
 
@@ -101,12 +103,7 @@ impl ComponentInfo for Q35 {
         add.component(patina_mm::component::sw_mmi_manager::SwMmiManager::new());
         add.component(patina_mm::component::communicator::MmCommunicator::new());
         add.component(q35_services::mm_test::QemuQ35MmTest::new());
-        add.component(patina_performance::component::Performance::new().with_measurements(
-            patina::performance::Measurement::DriverBindingStart     // Adds driver binding start measurements.
-               | patina::performance::Measurement::DriverBindingStop // Adds driver binding stop measurements.
-               | patina::performance::Measurement::LoadImage         // Adds load image measurements.
-               | patina::performance::Measurement::StartImage, // Adds start image measurements.
-        ));
+        add.component(patina_performance::component::Performance::new());
         add.component(patina_smbios::component::SmbiosProvider::new(3, 9));
         add.component(q35_services::smbios_platform::Q35SmbiosPlatform::new());
         add.component(patina_acpi::component::AcpiComponent::default());
@@ -123,6 +120,12 @@ impl PlatformInfo for Q35 {
     type MemoryInfo = Self;
     type ComponentInfo = Self;
     type Extractor = CompositeSectionExtractor;
+
+    const DEFAULT_PERFORMANCE_CONFIG: PerformanceConfig = PerformanceConfig::new()
+        .with_measurement(patina::performance::Measurement::DriverBindingStart)
+        .with_measurement(patina::performance::Measurement::DriverBindingStop)
+        .with_measurement(patina::performance::Measurement::LoadImage)
+        .with_measurement(patina::performance::Measurement::StartImage);
 }
 
 static CORE: Core<Q35> = Core::new(CompositeSectionExtractor::new());

--- a/src/armvirt/component/service/smbios_test.rs
+++ b/src/armvirt/component/service/smbios_test.rs
@@ -14,10 +14,10 @@ extern crate alloc;
 use alloc::{ffi::CString, vec, vec::Vec};
 use core::ffi::c_char;
 
-use patina::boot_services::{BootServices, StandardBootServices};
+use patina::standard::efi;
+use patina::uefi::boot_services::{BootServices, StandardBootServices};
 use patina_smbios::service::{SMBIOS_HANDLE_PI_RESERVED, SmbiosHandle, SmbiosTableHeader};
 use patina_test::{patina_test, u_assert, u_assert_eq, u_assert_ne};
-use r_efi::efi;
 
 /// Tests the SMBIOS C Protocol FFI layer by calling the protocol functions directly.
 /// This exercises the EDK2-compatible protocol layer (Add, UpdateString, Remove, GetNext)

--- a/src/q35/component/service/mm_config_provider.rs
+++ b/src/q35/component/service/mm_config_provider.rs
@@ -93,7 +93,7 @@ impl MmConfigurationProvider {
             let buffer = unsafe {
                 CommunicateBuffer::from_raw_parts(
                     hob.address as usize as *mut u8,
-                    hob.pages as usize * patina::base::UEFI_PAGE_SIZE,
+                    hob.pages as usize * patina::UEFI_PAGE_SIZE,
                     hob.buffer_type as u8,
                 )
             };

--- a/src/q35/component/service/smbios_test.rs
+++ b/src/q35/component/service/smbios_test.rs
@@ -14,10 +14,10 @@ extern crate alloc;
 use alloc::{ffi::CString, vec, vec::Vec};
 use core::ffi::c_char;
 
-use patina::boot_services::{BootServices, StandardBootServices};
+use patina::standard::efi;
+use patina::uefi::boot_services::{BootServices, StandardBootServices};
 use patina_smbios::service::{SMBIOS_HANDLE_PI_RESERVED, SmbiosHandle, SmbiosTableHeader};
 use patina_test::{patina_test, u_assert, u_assert_eq, u_assert_ne};
-use r_efi::efi;
 
 /// Tests the SMBIOS C Protocol FFI layer by calling the protocol functions directly.
 /// This exercises the EDK2-compatible protocol layer (Add, UpdateString, Remove, GetNext)


### PR DESCRIPTION
## Description

Update to Patina major version 23. To do this, the following changes are needed:

1. Update serial port creation for new mutable access and construction
2. Update patina_performance configuration to PlatformInfo
3. Update various SDK paths/names from SDK refactor

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Boot to OS on Armvirt and Q35 w/ Patina tests

## Integration Instructions

N/A
