### PR TITLE
v3.1.4: Update to patina 22.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,9 +313,9 @@ checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "patina"
-version = "22.2.2"
+version = "22.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33f5a85bed814fcd68499f5a4bdb2b63a600d28b2a1f8a6abcf0ffaa497b243"
+checksum = "a1c0c32987dc973a87d8052ccb2805749622a812d79d107ebe8d3ab6ea54da20"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -324,7 +324,6 @@ dependencies = [
  "fixedbitset",
  "goblin",
  "indoc",
- "linkme",
  "log",
  "num-traits",
  "patina_macro",
@@ -340,26 +339,24 @@ dependencies = [
 
 [[package]]
 name = "patina_acpi"
-version = "22.2.2"
+version = "22.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f70f23ae96f75436cc6205d8705b848f98d94257eb403b500c71826877e9d24"
+checksum = "d38d6dfcee592c4d6a7bdde5b15df6010526f839122f9b3c990ac2ddb6e2daa6"
 dependencies = [
  "log",
  "memoffset",
  "patina",
  "patina_test",
  "r-efi",
- "scroll",
- "spin",
  "zerocopy",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "patina_adv_logger"
-version = "22.2.2"
+version = "22.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "482d025b342b967460817b85b3475e0da6fd440fbe3bf4bec5ead48a86dfa816"
+checksum = "01da476a0d03a22d32138e77fc34d5388b3dba94e78c7668bc95da9463a95625"
 dependencies = [
  "log",
  "patina",
@@ -372,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "patina_debugger"
-version = "22.2.2"
+version = "22.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e22595096b205eb33dd999edcabb0fbe226f4ca7d29c48ad4ab985b7cd3d75"
+checksum = "34779f4a956300fcb46a556cd58cfc0900f3dfcfb8b9d754d8c441fe8c2e2bdd"
 dependencies = [
  "bitfield-struct",
  "cfg-if",
@@ -389,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "patina_dxe_core"
-version = "22.2.2"
+version = "22.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "295c1fb297e2e9859345b83a77252ff359eed033d6940f17d547c8d7a7f06d99"
+checksum = "91eded4221389333d24fef26fbfee6c8e43ca91a82b7edba182748242290e871"
 dependencies = [
  "arm-gic",
  "bitfield-struct",
@@ -407,7 +404,6 @@ dependencies = [
  "patina_internal_core",
  "patina_internal_cpu",
  "patina_paging",
- "patina_performance",
  "patina_test",
  "r-efi",
  "scroll",
@@ -417,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs"
-version = "22.2.2"
+version = "22.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9185a3a5b2d50924eeb1bd414e3f02c7e81005e79873c748529eb15891e61d93"
+checksum = "d41622396d7216e3a35ffe59b31d1fd3a03c8bf4fa25b10faf3895efff88588b"
 dependencies = [
  "log",
  "patina",
@@ -428,25 +424,23 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs_extractors"
-version = "22.2.2"
+version = "22.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae7ac517a0902753b68b85df22b13c6109f9961ab4528213aaffc188147c0c2"
+checksum = "079779cae9109b40cae5b5b25ada206ad61c154d69b34aa7774a2c3dfe3004d1"
 dependencies = [
  "alloc-no-stdlib",
  "brotli-decompressor",
  "crc32fast",
- "log",
  "lzma-rust2",
  "patina",
  "patina_ffs",
- "r-efi",
 ]
 
 [[package]]
 name = "patina_internal_core"
-version = "22.2.2"
+version = "22.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78e9ebb114827daf3428b541fe981ffa6d940dabd17f935108ebad44748da535"
+checksum = "d556a9e4564663a275513fc2f12f341528e33d7276661bd25d1cbbe72a325e03"
 dependencies = [
  "log",
  "r-efi",
@@ -455,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_cpu"
-version = "22.2.2"
+version = "22.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f0eabbe7ea70fff8bc0527fe8d938cb30b958aaf7d85cbabe86367f2fa45a8"
+checksum = "bfdbb1542a0262fb7df732b0dee71b964d990296887e8545685cff92a66d9990"
 dependencies = [
  "arm-gic",
  "cfg-if",
@@ -472,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "patina_macro"
-version = "22.2.2"
+version = "22.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5511ea31d52f0e60bb568a670bb5822d949bc10cdf6144f87d028ef70262ed5a"
+checksum = "332b5e03c603beb8439e48a24e9d40772ce9b5149d49a400e9acbfb8490475f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -484,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "patina_mm"
-version = "22.2.2"
+version = "22.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c579979babe6d011c3e8c7ab0195b52cd5bb91a339ca7af17be86de83f3ff9"
+checksum = "86d46c660c18a4bde3088f83158aa9d60e3d70c00703408220061afdd7a31649"
 dependencies = [
  "cfg-if",
  "log",
@@ -520,24 +514,23 @@ dependencies = [
 
 [[package]]
 name = "patina_performance"
-version = "22.2.2"
+version = "22.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b02509669fe2a1768765be4d7afe118224b40ee9bd0f5744dafa70c31fd919cb"
+checksum = "e114c4d81888881e18da9f97ad176bbd73fcb365508f8e6e32e62db0baeab796"
 dependencies = [
  "log",
  "patina",
  "patina_mm",
  "r-efi",
- "uuid",
  "zerocopy",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "patina_samples"
-version = "22.2.2"
+version = "22.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b746d6caa7442e94d1612ccb65b4ef129431124c64b11bf029fdfdb57df605"
+checksum = "f5916fb7c68ce2aba5a416585dba64d21e7c6f17c5a2bc63247b592188c0a3d6"
 dependencies = [
  "log",
  "patina",
@@ -547,25 +540,24 @@ dependencies = [
 
 [[package]]
 name = "patina_smbios"
-version = "22.2.2"
+version = "22.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b35a1ac96feab255a10ec5addf95a1db9420932e501bf1ab220fec63224a3c8"
+checksum = "4683e2cd009f3b2b46a22bedc348a49ffc134ffa75af365211b17df12e1276ed"
 dependencies = [
  "bitfield-struct",
  "log",
  "patina",
  "patina_macro",
  "r-efi",
- "spin",
  "zerocopy",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "patina_stacktrace"
-version = "22.2.2"
+version = "22.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb54dbb86633aeef457aa07bc58484a2246c537095f24df1e89a45cbf414a2b3"
+checksum = "99b7b6d077b9fc286705b4f49744f12e3dd4305722384e7ae1a224ee9a3a9b33"
 dependencies = [
  "cfg-if",
  "log",
@@ -573,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "patina_test"
-version = "22.2.2"
+version = "22.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f28ddadd57470e528fa4e2ec0eec8464ed4ee21c0efc2b902ce63020f1012d"
+checksum = "cb1fa755c3d066a873854789c628cc9e3662ce0f3590698ff4ef7f48be45d392"
 dependencies = [
  "linkme",
  "log",
@@ -614,7 +606,7 @@ checksum = "8189cbf0422ac15d7d544ed5f331fbe4e5b9da88133568fd359083b186a547f3"
 
 [[package]]
 name = "qemu_dxe_core"
-version = "3.1.3"
+version = "3.1.4"
 dependencies = [
  "log",
  "patina",
@@ -682,9 +674,9 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "safe-mmio"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4813ee49326057f105d6d8ca3d8f9265095f26aa7b42094e487028403a594f4c"
+checksum = "ce5e4ed477d6ebc07e01ce97b87fe319e6b62d0ab2564594db6a8c4cdc29ffd9"
 dependencies = [
  "zerocopy",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qemu_dxe_core"
-version = "3.1.3"
+version = "3.1.4"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Description

Updates to the latest patina release. See the release notes for more details about changes in the release:

https://github.com/OpenDevicePartnership/patina/releases/tag/patina-v22.2.3

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
- Boot ArmVirt and Q35 to EFI shell

## Integration Instructions

- N/A