### PR TITLE
Fail QEMU on panic instead of looping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ patina_test = { version = "22", features = ["test-runner"] }
 log = { version = "^0.4", default-features = false, features = [
   "release_max_level_info",
 ] }
-qemu-exit = { version = "4", optional = true }
+qemu-exit = { version = "4" }
 r-efi = { version = "7", default-features = false }
 x86_64 = { version = "=0.15.4", default-features = false, features = [
   "instructions",
@@ -77,4 +77,4 @@ aarch64 = []
 std = []
 build_debugger = ["patina_dxe_core/debugger_reload"]
 enable_debugger = ["build_debugger"]
-exit_on_patina_test_failure = ["qemu-exit"]
+exit_on_patina_test_failure = []

--- a/bin/arm_virt_dxe_core.rs
+++ b/bin/arm_virt_dxe_core.rs
@@ -21,7 +21,6 @@ use patina_adv_logger::{
 use patina_dxe_core::*;
 use patina_ffs_extractors::CompositeSectionExtractor;
 use patina_stacktrace::StackTrace;
-#[cfg(feature = "exit_on_patina_test_failure")]
 use qemu_exit::QEMUExit;
 use qemu_resources::armvirt::component::service as armvirt_services;
 extern crate alloc;

--- a/bin/arm_virt_dxe_core.rs
+++ b/bin/arm_virt_dxe_core.rs
@@ -36,7 +36,7 @@ fn panic(info: &PanicInfo) -> ! {
 
     patina_debugger::breakpoint();
 
-    loop {}
+    qemu_fail()
 }
 
 static LOGGER: AdvancedLogger<UartPl011> = AdvancedLogger::new(
@@ -98,7 +98,7 @@ impl ComponentInfo for ArmVirt {
         add.component(patina_test::component::TestRunner::default().with_callback(|test_name, err_msg| {
             log::error!("Test {} failed: {}", test_name, err_msg);
             #[cfg(feature = "exit_on_patina_test_failure")]
-            qemu_exit::AArch64::new().exit_failure();
+            qemu_fail();
         }));
         add.component(patina_performance::component::Performance::new().with_measurements(
             patina::performance::Measurement::DriverBindingStart     // Adds driver binding start measurements.
@@ -137,4 +137,8 @@ pub unsafe extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
 
     log::info!("DXE Core Platform Binary v{}", env!("CARGO_PKG_VERSION"));
     CORE.entry_point(physical_hob_list)
+}
+
+fn qemu_fail() -> ! {
+    qemu_exit::AArch64::new().exit_failure()
 }

--- a/bin/ovmf_dxe_core.rs
+++ b/bin/ovmf_dxe_core.rs
@@ -30,6 +30,8 @@ fn panic(info: &PanicInfo) -> ! {
 
     patina_debugger::breakpoint();
 
+    // Because OVMF does not have a QEMU exit device, we cannot exit the emulator on panic.
+    // Instead, we enter an infinite loop to halt execution.
     loop {}
 }
 

--- a/bin/q35_dxe_core.rs
+++ b/bin/q35_dxe_core.rs
@@ -22,7 +22,6 @@ use patina_stacktrace::StackTrace;
 use qemu_resources::q35::component::service as q35_services;
 extern crate alloc;
 use alloc::vec;
-#[cfg(feature = "exit_on_patina_test_failure")]
 use qemu_exit::QEMUExit;
 use qemu_resources::q35::timer;
 

--- a/bin/q35_dxe_core.rs
+++ b/bin/q35_dxe_core.rs
@@ -36,7 +36,7 @@ fn panic(info: &PanicInfo) -> ! {
 
     patina_debugger::breakpoint();
 
-    loop {}
+    qemu_fail()
 }
 
 /// Port address of the ACPI PM Timer.
@@ -114,11 +114,7 @@ impl ComponentInfo for Q35 {
         add.component(patina_test::component::TestRunner::default().with_callback(|test_name, err_msg| {
             log::error!("Test {} failed: {}", test_name, err_msg);
             #[cfg(feature = "exit_on_patina_test_failure")]
-            // SAFETY: `X86::new` is unsafe as of qemu-exit 4.0.0 because the caller must
-            // ensure that the provided I/O base matches a QEMU `isa-debug-exit` device. The
-            // QEMU command line used to launch this firmware (in patina-qemu) configures
-            // `isa-debug-exit,iobase=0xf4,iosize=0x04`.
-            unsafe { qemu_exit::X86::new(0xf4, 0x1) }.exit_failure();
+            qemu_fail();
         }));
     }
 }
@@ -148,4 +144,12 @@ pub unsafe extern "efiapi" fn _start(physical_hob_list: *const c_void) -> ! {
 
     log::info!("DXE Core Platform Binary v{}", env!("CARGO_PKG_VERSION"));
     CORE.entry_point(physical_hob_list)
+}
+
+fn qemu_fail() -> ! {
+    // SAFETY: `X86::new` is unsafe as of qemu-exit 4.0.0 because the caller must
+    // ensure that the provided I/O base matches a QEMU `isa-debug-exit` device. The
+    // QEMU command line used to launch this firmware (in patina-qemu) configures
+    // `isa-debug-exit,iobase=0xf4,iosize=0x04`.
+    unsafe { qemu_exit::X86::new(0xf4, 0x1) }.exit_failure()
 }


### PR DESCRIPTION
## Description

This commit changes the panic handlers for Q35 and ArmVirt to call `qemu_exit` to fail the QEMU execution instead of looping indefinitely. This allows for better automated testing such as CI, test scripts, and AI based testing.

This intentionally leaves out OVMF because qemu-exit requires that qemu be launched with specific parameters, e.g. `isa-debug-exit`, which are part of patina-qemu's scripts but not generally used in EDK2.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Boot test on ArmVirt and Q35

## Integration Instructions

N/A
