### PR TITLE
v3.2.1: Update to patina 23.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,9 +313,9 @@ checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "patina"
-version = "23.0.1"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6286249aedf455f55c8b7d22c6c19cabfd7e5fa7e492f959e45615487de7091"
+checksum = "999f34c57de4a24b2a838e8271c9ad1dd7b7fa921f9d543ef3e930bac9df5d32"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -339,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "patina_acpi"
-version = "23.0.1"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121c8ebb9946f5622df78b53ab308957d3ce4d1c40e70f3494d82163fbc50d96"
+checksum = "37091fcbe58d6f6d5b873c98ec01f72e49b52285ab73ac17872344d0568c6eea"
 dependencies = [
  "log",
  "memoffset",
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "patina_adv_logger"
-version = "23.0.1"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e3503019aa48206a7ca7a074eba742e848bf4516a5324d143a281d058e5ff88"
+checksum = "ab8a429b89ceef3954de2439c2f6d3c5060fcc97c4c8f431799ed7effa1cfa04"
 dependencies = [
  "log",
  "patina",
@@ -367,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "patina_debugger"
-version = "23.0.1"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6b1f18c90c29588fcd6fab08ad3f0a83ccc2588708a52723f8130c43e0a212"
+checksum = "6f97f4ad094cec0e58512f30644235ab58601783275c670e5b00383e00858d94"
 dependencies = [
  "bitfield-struct",
  "cfg-if",
@@ -384,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "patina_dxe_core"
-version = "23.0.1"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e7b5400af1c3d3852900de9ff978bbe3bac58efad1999783d951bf6e428c1a"
+checksum = "e92bd5ba55400a1fe64210ebe6f7a91328875a9c4bcd23da7012f4dc273f9e74"
 dependencies = [
  "arm-gic",
  "bitfield-struct",
@@ -410,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs"
-version = "23.0.1"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e7e5908589891ee535d4759efc97e8986f66617f6d76678dc30e65637cce23"
+checksum = "1a971e3758d26bcab43eb4994e1440bf3fc9864fabaa9dde5329146784734d56"
 dependencies = [
  "log",
  "patina",
@@ -420,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "patina_ffs_extractors"
-version = "23.0.1"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb94681a0e9b70eddbed0ace0004624af02429d5f5bdea46f3c99d55e55c249"
+checksum = "4a77793a68241e2c510fea843136a2e6e166c3886e8dd36ba35e37deecb50bd8"
 dependencies = [
  "alloc-no-stdlib",
  "brotli-decompressor",
@@ -434,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_core"
-version = "23.0.1"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76faac05360da91240ac836853a0a811bd3628c0ccf888bb260b1a8caad09f5c"
+checksum = "e67ec679dc1bd53a5f228d18aa3d94a0e708e59ef4c3fa510136a9b98cfa4cd3"
 dependencies = [
  "log",
  "patina",
@@ -445,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "patina_internal_cpu"
-version = "23.0.1"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88d3cd89526e00e432da20f58d00c325aa9d7b5236dd5402f7ce2d70dfee268"
+checksum = "fccc11b35fc85afe6b3f64c8b1fca9438cb763e6042ef98a3542fe673b2f0957"
 dependencies = [
  "arm-gic",
  "cfg-if",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "patina_macro"
-version = "23.0.1"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219e262cfcee93024c95d9de2a1e7cc1ba87afcb83cdd226ad49666be6518f7e"
+checksum = "1fe33992bbe3d65d48a724886af950fe65a67eae50a2995637536d8e44b166fb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -473,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "patina_mm"
-version = "23.0.1"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4bd9783b646136ed81e4eb75721911a1b70de177b66266ce493c44b8490dc61"
+checksum = "a529e915ff5bef4c86814dea1a32f9c0e53355ab2542b582a59c5ea1fb30a603"
 dependencies = [
  "cfg-if",
  "log",
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "patina_performance"
-version = "23.0.1"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49802c25665b8d1187f45da1634b5f52bf5a7dd724d25a836ef0abad6a2c6f9"
+checksum = "78631b90aa5e5c170e677cb9a951c525c5786085970dc840dfe77ea5144d31ac"
 dependencies = [
  "log",
  "patina",
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "patina_samples"
-version = "23.0.1"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c873064b62cdd4cf068e07af80060dee5a72cca62923e18ae148a0a6ccbb31"
+checksum = "ec944f7ec71ccd83dcbc0364099084e2e18bccdc231873e16343a50c0597eaa8"
 dependencies = [
  "log",
  "patina",
@@ -533,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "patina_smbios"
-version = "23.0.1"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e394639ba244657c4d09e873f5c7aab9738361cfc282bb21f3888d3093468b"
+checksum = "f2f8d4d57bd2772186996c1ff702e3d257a6aa3e06ce27c3d86235c29a4935ce"
 dependencies = [
  "bitfield-struct",
  "log",
@@ -547,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "patina_stacktrace"
-version = "23.0.1"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bbac80083e6858e9c53fe3ebb360f9b8ebd336df882e0aea343aba260b8b81"
+checksum = "8fed5811f5ec17e36423c9094566716beae85e67950194cff7240a6ba7d83577"
 dependencies = [
  "cfg-if",
  "log",
@@ -557,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "patina_test"
-version = "23.0.1"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18144b2a28929d7227f51a9fa40c249ba77d7168825b8442ff68911d58217431"
+checksum = "4947981987dcb72e196469b4c3c3013453430ce4dabfeb92cd0564bedad25ac8"
 dependencies = [
  "linkme",
  "log",
@@ -597,7 +597,7 @@ checksum = "8189cbf0422ac15d7d544ed5f331fbe4e5b9da88133568fd359083b186a547f3"
 
 [[package]]
 name = "qemu_dxe_core"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "log",
  "patina",
@@ -629,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "7.0.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1b35d612599fa2eed43b064164175ebe98c88de47c8cc6cc6c50d6502aa6abe"
+checksum = "b0ff379dd174eec5b2cab797063a2e7592dfcf0bf0323a50eeee724ee3537f13"
 
 [[package]]
 name = "radium"
@@ -772,18 +772,18 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -792,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -884,18 +884,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qemu_dxe_core"
-version = "3.2.0"
+version = "3.2.1"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Description

Updates to the latest patina release. See the release notes for more details about changes in the release:

https://github.com/OpenDevicePartnership/patina/releases/tag/patina-v23.0.2

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `cargo make all`
- QEMU ArmVirt & Q35 boot to EFI shell

## Integration Instructions

- N/A